### PR TITLE
refactor: UI consistency round 2 — card stack, inline panels, sync perf

### DIFF
--- a/src/main/NodeManager.ts
+++ b/src/main/NodeManager.ts
@@ -193,7 +193,7 @@ export class NodeManager {
       const url = `${baseUrl.replace(/\/$/, '')}/json_rpc`;
 
       const controller = new AbortController();
-      const timeoutId = setTimeout(() => controller.abort(), 15000); // Longer timeout to prevent disconnection
+      const timeoutId = setTimeout(() => controller.abort(), 8000);
       const response = await net.fetch(url, {
         method: 'POST',
         body: JSON.stringify({ jsonrpc: '2.0', id: '0', method: 'get_info' }),

--- a/src/main/SyncWatcher.ts
+++ b/src/main/SyncWatcher.ts
@@ -15,11 +15,15 @@ export class SyncWatcher {
   // Daemon height cache — no need to hit the remote node every 2s
   private cachedDaemonHeight: number = 0;
   private lastDaemonHeightFetch: number = 0;
-  private static readonly DAEMON_HEIGHT_TTL = 30_000; // 30 seconds
+  private static readonly DAEMON_HEIGHT_TTL = 60_000; // 60 seconds
 
   // Padded sync state
   private isSyncing: boolean = false;
   private syncAborted: boolean = false;
+
+  // Throttle SYNC_UPDATE events to avoid IPC flood
+  private lastSyncEventTime: number = 0;
+  private static readonly SYNC_EVENT_THROTTLE = 1_000; // 1 second
 
   constructor(mainWindow: BrowserWindow, onLog?: (source: string, level: 'info' | 'error', message: string) => void) {
     this.mainWindow = mainWindow;
@@ -40,6 +44,10 @@ export class SyncWatcher {
   private async runLoop(): Promise<void> {
     try {
       if (!this.intervalId) return;
+
+      // While padded sync is active, it owns the RPC — skip heavy polling
+      // to avoid contention on the single-threaded wallet-rpc
+      if (this.isSyncing) return;
 
       // 1. Check wallet height + cached daemon height
       await this.checkSyncStatus();
@@ -136,7 +144,7 @@ export class SyncWatcher {
 
       // Fetch daemon height (fresh, ignore cache for initial sync)
       this.lastDaemonHeightFetch = 0;
-      const targetHeight = await this.getDaemonHeight();
+      let targetHeight = await this.getDaemonHeight();
 
       if (targetHeight <= 0) {
         this.emitLog('Sync', 'info', '⏳ Daemon height unknown, falling back to passive sync');
@@ -154,6 +162,7 @@ export class SyncWatcher {
       this.emitLog('Sync', 'info', `📦 ${gap} blocks behind (${currentHeight} → ${targetHeight}), chunking refresh...`);
 
       // Chunk loop — call refresh repeatedly until caught up
+      let chunkCounter = 0;
       while (!this.syncAborted) {
         try {
           // refresh returns { blocks_fetched, received_money }
@@ -165,35 +174,49 @@ export class SyncWatcher {
           const fetched = result.blocks_fetched || 0;
 
           if (fetched === 0) {
-            // Caught up or stalled — recheck daemon height
+            // Caught up or stalled — recheck daemon height with a real get_height
             this.lastDaemonHeightFetch = 0; // Force refresh
-            const freshTarget = await this.getDaemonHeight();
-            const heightNow = await (WalletManager as any).callRpc('get_height');
+            const [freshTarget, heightNow] = await Promise.all([
+              this.getDaemonHeight(),
+              (WalletManager as any).callRpc('get_height')
+            ]);
             currentHeight = heightNow.height || currentHeight;
 
             if (freshTarget - currentHeight <= 10) {
               this.emitLog('Sync', 'info', `✅ Padded sync complete at block ${currentHeight}`);
               break;
             }
-            // Small pause before retrying if no blocks fetched
-            await new Promise(r => setTimeout(r, 1000));
+            await new Promise(r => setTimeout(r, 500));
             continue;
           }
 
-          // Update tracked height
+          // Use blocks_fetched to estimate height — avoids an extra get_height RPC per chunk.
+          // Periodically verify with actual get_height to prevent drift.
           currentHeight += fetched;
+          chunkCounter++;
 
-          // Push progress to UI
+          // Verify actual height every 20 chunks to correct any drift
+          if (chunkCounter % 20 === 0) {
+            const heightCheck = await (WalletManager as any).callRpc('get_height');
+            currentHeight = heightCheck.height || currentHeight;
+          }
+
+          // Push progress to UI (throttled to avoid IPC flood)
           this.lastKnownHeight = currentHeight;
-          this.pushEvent({
-            type: 'SYNC_UPDATE',
-            payload: { height: currentHeight, daemonHeight: targetHeight }
-          });
+          const now = Date.now();
+          if (now - this.lastSyncEventTime >= SyncWatcher.SYNC_EVENT_THROTTLE) {
+            this.lastSyncEventTime = now;
+            this.pushEvent({
+              type: 'SYNC_UPDATE',
+              payload: { height: currentHeight, daemonHeight: targetHeight }
+            });
+          }
 
-          // Refresh daemon height periodically during long syncs
-          if (this.loopCounter % 10 === 0) {
-            this.lastDaemonHeightFetch = 0;
-            await this.getDaemonHeight();
+          // Refresh daemon height every 30 chunks (non-blocking, fire-and-forget style)
+          if (chunkCounter % 30 === 0) {
+            this.getDaemonHeight().then(h => {
+              if (h > targetHeight) targetHeight = h;
+            }).catch(() => {});
           }
         } catch (e: any) {
           // refresh can timeout on slow nodes — just retry
@@ -202,8 +225,13 @@ export class SyncWatcher {
         }
       }
 
-      // Final balance check after sync completes
+      // Final sync update + balance check after sync completes
       if (!this.syncAborted) {
+        // Emit final SYNC_UPDATE (bypass throttle)
+        this.pushEvent({
+          type: 'SYNC_UPDATE',
+          payload: { height: currentHeight, daemonHeight: targetHeight }
+        });
         await this.checkBalance();
         // Save progress immediately
         await (WalletManager as any).callRpc('store', {}).catch(() => {});

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -339,7 +339,7 @@ function MainApp() {
       <style>{` .scanline-overlay { background: linear-gradient(to bottom, transparent 50%, rgba(0, 77, 19, var(--scanline-opacity, 0)) 50%); background-size: 100% 4px; pointer-events: none; z-index: 100; display: block; } `}</style>
       <div className="fixed inset-0 scanline-overlay pointer-events-none z-[100]"></div>
 
-      <aside className="w-56 shrink-0 flex flex-col border-r border-xmr-border/40 bg-xmr-surface backdrop-blur-xl z-50 rounded-r-md" style={{ WebkitAppRegion: 'drag' } as any}>
+      <aside className="w-56 shrink-0 flex flex-col border-r border-xmr-border/40 bg-xmr-surface backdrop-blur-xl z-50" style={{ WebkitAppRegion: 'drag' } as any}>
         {/* ─── Header ─── */}
         <div className="px-5 pt-6 pb-5 mt-3 flex flex-col items-center gap-2.5" style={{ WebkitAppRegion: 'no-drag' } as any}>
           <div className="relative group cursor-pointer" onClick={() => setView('home')}>
@@ -365,6 +365,24 @@ function MainApp() {
             </div>
           </div>
         </div>
+
+        {/* ─── Portfolio Card ─── */}
+        {vault.accounts.length > 0 && (
+          <div
+            className="mx-3 mt-1 p-3 bg-gradient-to-br from-xmr-green/10 to-transparent border border-xmr-border/30 rounded-lg cursor-pointer hover:border-xmr-green/30 transition-all"
+            style={{ WebkitAppRegion: 'no-drag' } as any}
+            onClick={() => setView('vault')}
+          >
+            <div className="text-[8px] font-bold uppercase tracking-[0.25em] text-xmr-dim mb-1">Total Portfolio</div>
+            <div className="font-[var(--font-display)] text-base font-black text-xmr-green leading-tight">
+              {vault.accounts.reduce((sum, a) => sum + parseFloat(a.balance || '0'), 0).toFixed(4)}
+              <span className="text-[9px] text-xmr-dim font-normal ml-1">XMR</span>
+            </div>
+            <div className="text-[8px] text-xmr-dim/50 mt-0.5 uppercase tracking-wider">
+              {vault.accounts.length} accounts
+            </div>
+          </div>
+        )}
 
         {/* ─── Grouped Navigation ─── */}
         <nav className="flex-grow overflow-y-auto custom-scrollbar space-y-1 pb-2" style={{ WebkitAppRegion: 'no-drag' } as any}>

--- a/src/renderer/components/AuthView.tsx
+++ b/src/renderer/components/AuthView.tsx
@@ -36,7 +36,9 @@ export function AuthView({ onUnlock, isInitialSetup, identities, activeId, onSwi
       setStep('AUTH');
       setHasInitialized(true);
     } else if (!hasInitialized && identities.length === 0) {
-      setStep('LABEL');
+      // First launch: skip to password creation directly (Exodus-style)
+      setNewName('My_Wallet');
+      setStep('NEW_PASSWORD');
     }
   }, [identities.length, hasInitialized]);
 
@@ -132,8 +134,8 @@ export function AuthView({ onUnlock, isInitialSetup, identities, activeId, onSwi
           <div className="inline-block p-3 rounded-full bg-xmr-green/10 border border-xmr-green/20 mb-1">
             {step === 'AUTH' ? <Shield size={40} className={isProcessing ? 'animate-pulse' : ''} /> : <ShieldCheck size={40} />}
           </div>
-          <h1 className="text-2xl font-black italic uppercase text-xmr-green tracking-tighter">
-            {step === 'RESTORE' ? 'Identity_Recovery' : step === 'NEW_PASSWORD' ? 'Initialize_Vault' : (identities.length === 0 || step === 'LABEL') ? 'New_Tactical_ID' : 'Vault_Authorization'}
+          <h1 className="text-2xl font-black uppercase text-xmr-green tracking-tight" style={{ fontFamily: 'var(--font-display)' }}>
+            {step === 'RESTORE' ? 'Restore Wallet' : step === 'NEW_PASSWORD' ? (identities.length === 0 ? 'Create Your Wallet' : 'Set Password') : step === 'LABEL' ? 'Name Your Wallet' : 'Unlock Vault'}
           </h1>
           <div className="flex flex-col items-center gap-1">
             <div className="flex items-center justify-center gap-2 text-[11px] text-xmr-dim uppercase tracking-widest">

--- a/src/renderer/components/ExchangeView.tsx
+++ b/src/renderer/components/ExchangeView.tsx
@@ -145,7 +145,8 @@ export function ExchangeView({ localXmrAddress }: ExchangeViewProps) {
         generatingSubRef.current = false;
       }
     })();
-  }, [toCoin, localXmrAddress, createSubaddress, subaddresses, isGhost]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- subaddresses intentionally excluded to prevent infinite loop (createSubaddress updates subaddresses)
+  }, [toCoin, localXmrAddress, isGhost]);
 
   // ─── Debounced quote/estimate ───
   useEffect(() => {

--- a/src/renderer/components/HomeView.tsx
+++ b/src/renderer/components/HomeView.tsx
@@ -37,7 +37,7 @@ export function HomeView({ setView, stats, loading }: HomeViewProps) {
               Real_Market_Price (No-KYC)
            </div>
            <div className="relative inline-block">
-              <h1 className="text-8xl font-black text-xmr-accent tracking-tighter italic">
+              <h1 className="text-8xl font-black text-xmr-accent tracking-tighter" style={{ fontFamily: 'var(--font-display)' }}>
                 ${loading ? '---.--' : stats?.price.street}
               </h1>
               {!loading && stats?.price.premium && (

--- a/src/renderer/components/VaultView.tsx
+++ b/src/renderer/components/VaultView.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react';
-import { Skull, RefreshCw, Key, Send, Download, Wind, Loader2, Edit2, Dices, Scissors } from 'lucide-react';
+import { RefreshCw, Key, Send, Download, Wind, Loader2, Edit2, Scissors, MoreVertical, Plus } from 'lucide-react';
 import { Card } from './Card';
 import { AddressBook } from './vault/AddressBook';
 import { AddressList } from './vault/AddressList';
@@ -33,10 +33,11 @@ export function VaultView({ setView, vault, handleBurn, appConfig }: VaultViewPr
   const [dispatchAddr, setDispatchAddr] = useState('');
   const [selectedSubaddress, setSelectedSubaddress] = useState<any>(null);
   const [dispatchSubIndex, setDispatchSubIndex] = useState<number | undefined>(undefined);
-  const [showAccountDropdown, setShowAccountDropdown] = useState(false);
+  const [showCardMenu, setShowCardMenu] = useState(false);
   const [editingAccountId, setEditingAccountId] = useState<number | null>(null);
   const [editAccountName, setEditAccountName] = useState('');
   const [hideZeroBalances, setHideZeroBalances] = useState(false);
+  const [switching, setSwitching] = useState(false);
 
   const currentAcc = accounts.find(a => a.index === selectedAccountIndex);
   const currentAccBalance = currentAcc?.balance || '0.0000';
@@ -44,7 +45,6 @@ export function VaultView({ setView, vault, handleBurn, appConfig }: VaultViewPr
 
   useEffect(() => {
     const loadAddressBook = async () => {
-      // Assume address book is stored under a specific key in the config object
       const bookKey = `address_book_${activeId}` as keyof typeof appConfig;
       setContacts((appConfig as any)[bookKey] || []);
       setHideZeroBalances(!!appConfig.hide_zero_balances);
@@ -52,29 +52,33 @@ export function VaultView({ setView, vault, handleBurn, appConfig }: VaultViewPr
     if (appConfig) loadAddressBook();
   }, [activeId, appConfig]);
 
-  // Click-away listener to close the dropdown
-  const dropdownRef = useRef<HTMLDivElement>(null);
+  const cardMenuRef = useRef<HTMLDivElement>(null);
   useEffect(() => {
     if (requestedAction) {
       if (requestedAction === 'OPEN_SEND') setModals(prev => ({ ...prev, send: true }));
       else if (requestedAction === 'OPEN_RECEIVE') setModals(prev => ({ ...prev, receive: true }));
       else if (requestedAction === 'OPEN_CHURN') setModals(prev => ({ ...prev, churn: true }));
       else if (requestedAction === 'OPEN_SPLINTER') setModals(prev => ({ ...prev, splinter: true }));
-
-      // Clear the action so it doesn't re-trigger
       vault.setRequestedAction(null);
     }
   }, [requestedAction, vault]);
 
   useEffect(() => {
     function handleClickOutside(event: MouseEvent) {
-      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
-        setShowAccountDropdown(false);
+      if (cardMenuRef.current && !cardMenuRef.current.contains(event.target as Node)) {
+        setShowCardMenu(false);
       }
     }
     document.addEventListener("mousedown", handleClickOutside);
     return () => document.removeEventListener("mousedown", handleClickOutside);
   }, []);
+
+  // Card switch animation
+  useEffect(() => {
+    setSwitching(true);
+    const t = setTimeout(() => setSwitching(false), 150);
+    return () => clearTimeout(t);
+  }, [selectedAccountIndex]);
 
   const saveContacts = async (updated: any[]) => {
     setContacts(updated);
@@ -102,7 +106,6 @@ export function VaultView({ setView, vault, handleBurn, appConfig }: VaultViewPr
     }
   };
 
-  // 2. View mnemonic seed (safely retrieved via backend)
   const revealSeed = async () => {
     if (!confirm("⚠️ SECURITY WARNING ⚠️\n\nReveal Master Seed?\nEnsure no cameras or screen recording software is active.")) return;
 
@@ -132,36 +135,31 @@ export function VaultView({ setView, vault, handleBurn, appConfig }: VaultViewPr
   const isSyncing = status === 'SYNCING' || status === 'READY';
   const isFullySynced = status === 'SYNCED';
 
+  const cycleAccount = () => {
+    if (accounts.length <= 1) return;
+    const currentIdx = accounts.findIndex(a => a.index === selectedAccountIndex);
+    const nextIdx = (currentIdx + 1) % accounts.length;
+    setSelectedAccountIndex(accounts[nextIdx].index);
+  };
+
+  const hasNoBalance = parseFloat(currentAcc?.unlockedBalance || '0') <= 0;
+
+  const quickActions = [
+    { label: 'Dispatch', icon: Send, onClick: () => setModals(prev => ({ ...prev, send: true })), disabled: isSyncing },
+    { label: 'Receive', icon: Download, onClick: () => setModals(prev => ({ ...prev, receive: true })), disabled: isSyncing },
+    { label: 'Churn', icon: Wind, onClick: () => setModals(prev => ({ ...prev, churn: true })), disabled: isSyncing || isSending || hasNoBalance },
+    { label: 'Splinter', icon: Scissors, onClick: () => setModals(prev => ({ ...prev, splinter: true })), disabled: isSyncing || isSending || hasNoBalance },
+    { label: 'Sync', icon: RefreshCw, onClick: refresh, disabled: false, spin: isSyncing || isSending },
+  ];
+
   return (
     <div className="max-w-6xl mx-auto space-y-6 py-2 pt-0 animate-in fade-in zoom-in-95 duration-300 font-black relative">
 
-      {/* 1. HEADER */}
       {/* 1. HEADER */}
       <div className="flex justify-between items-end border-b border-xmr-border/30 pb-4 relative z-10 font-black">
         <div>
           <button onClick={() => setView('home')} className="text-xs text-xmr-dim hover:text-xmr-green mb-1 flex items-center gap-1 cursor-pointer font-black transition-all uppercase tracking-widest">[ DASHBOARD ]</button>
           <h2 className="text-3xl font-black italic uppercase tracking-tighter text-xmr-green font-mono leading-none">Vault_Storage</h2>
-        </div>
-        <div className="flex gap-2 font-black">
-          <button
-            onClick={() => setModals(prev => ({ ...prev, splinter: true }))}
-            disabled={isSyncing || isSending || parseFloat(currentAcc?.unlockedBalance || '0') <= 0}
-            className="px-3 py-1.5 border border-xmr-accent/50 text-xmr-accent text-[11px] hover:bg-xmr-accent/10 transition-all flex items-center gap-2 cursor-pointer uppercase font-black disabled:opacity-50"
-            title="Shatter UTXOs / Fragment Balance"
-          >
-            <Scissors size={10} /> Splinter
-          </button>
-          <button
-            onClick={() => setModals(prev => ({ ...prev, churn: true }))}
-            disabled={isSyncing || isSending || parseFloat(currentAcc?.unlockedBalance || '0') <= 0}
-            className="px-3 py-1.5 border border-xmr-green/50 text-xmr-green text-[11px] hover:bg-xmr-green/10 transition-all flex items-center gap-2 cursor-pointer uppercase font-black disabled:opacity-50"
-            title="Consolidate UTXOs / Break Heuristics"
-          >
-            <Wind size={10} /> Churn_UTXOs
-          </button>
-          <button onClick={refresh} className="px-3 py-1.5 border border-xmr-border text-[11px] hover:bg-xmr-green/10 transition-all flex items-center gap-2 cursor-pointer uppercase font-black">
-            <RefreshCw size={10} className={isSyncing || isSending ? 'animate-spin' : ''} /> Sync_Ledger
-          </button>
         </div>
       </div>
 
@@ -177,75 +175,192 @@ export function VaultView({ setView, vault, handleBurn, appConfig }: VaultViewPr
         </div>
       )}
 
-      {/* 2. TOP GRID (Balances & ID) */}
-      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 relative z-10 font-black font-mono">
-        <Card topGradientAccentColor="xmr-green" className="lg:col-span-2 flex flex-col justify-between">
-          <div className="flex justify-between items-start">
-            <div>
-              <div className="flex items-center gap-3 mb-1">
-                {/* 🚀 CORE: Account Switcher - Elevated to Headline position */}
-                <div
-                  onClick={() => setShowAccountDropdown(true)}
-                  className="flex items-center bg-transparent border border-xmr-border/30 hover:border-xmr-green/50 rounded px-3 py-1.5 gap-3 cursor-pointer transition-all w-fit group"
-                >
-                  <div className="flex flex-raw space-x-2">
-                    <span className="text-sm text-xmr-dim uppercase font-bold tracking-[0.2em] group-hover:text-xmr-green transition-colors">{String(selectedAccountIndex).padStart(2, '0')}</span>
-                    <span className='text-sm text-xmr-dim uppercase font-bold tracking-[0.2em] group-hover:text-xmr-green transition-colors'>-</span>
-                    <span className="text-sm text-xmr-green font-black uppercase tracking-widest">
+      {/* 2. CARD STACK + IDENTITY STATUS */}
+      <div className="grid grid-cols-1 lg:grid-cols-[2fr_1fr] gap-6 relative z-10 font-black font-mono">
+
+        {/* LEFT: Card Stack + Quick Actions */}
+        <div className="flex flex-col gap-5">
+
+          {/* Card Stack */}
+          <div className="relative h-[220px] cursor-pointer" style={{ perspective: '800px' }} onClick={cycleAccount}>
+            {/* Background card 3 (deepest) */}
+            {accounts.length >= 3 && (
+              <div
+                className="absolute top-0 left-6 right-6 h-[200px] bg-xmr-surface border border-xmr-border/15 rounded-lg"
+                style={{ transform: 'translateY(0px) scale(0.92)', opacity: 0.3 }}
+              />
+            )}
+            {/* Background card 2 */}
+            {accounts.length >= 2 && (
+              <div
+                className="absolute top-0 left-3.5 right-3.5 h-[200px] bg-xmr-surface border border-xmr-border/20 rounded-lg"
+                style={{ transform: 'translateY(6px) scale(0.96)', opacity: 0.5 }}
+              />
+            )}
+
+            {/* Main card (active account) */}
+            <div
+              className={`absolute top-0 left-0 right-0 h-[200px] bg-gradient-to-br from-xmr-green/5 via-xmr-green/8 to-xmr-green/3 bg-xmr-surface border border-xmr-green/40 rounded-lg p-6 flex flex-col justify-between shadow-[0_8px_32px_rgba(0,0,0,0.5)] transition-all duration-150 ${switching ? 'scale-[0.97] opacity-70' : 'scale-100 opacity-100'}`}
+              style={{ transform: `translateY(14px) ${switching ? 'scale(0.97)' : 'scale(1)'}` }}
+            >
+              {/* Top glow */}
+              <div className="absolute top-0 left-0 right-0 h-[2px] bg-gradient-to-r from-transparent via-xmr-green/50 to-transparent rounded-t-lg" />
+
+              {/* Watermark */}
+              <div className="absolute right-5 bottom-4 text-7xl font-black text-xmr-green/5 tracking-tighter select-none pointer-events-none">XMR</div>
+
+              {/* Card header */}
+              <div className="flex justify-between items-start relative z-10">
+                <div>
+                  <div className="text-[11px] text-xmr-dim font-bold tracking-[0.2em] uppercase">ACCT #{String(selectedAccountIndex).padStart(2, '0')}</div>
+                  {editingAccountId === selectedAccountIndex ? (
+                    <input
+                      autoFocus
+                      value={editAccountName}
+                      onClick={(e) => e.stopPropagation()}
+                      onChange={(e) => setEditAccountName(e.target.value)}
+                      onBlur={async () => {
+                        if (editAccountName.trim() && editAccountName !== currentAcc?.label) {
+                          await vault.renameAccount(selectedAccountIndex, editAccountName.trim());
+                        }
+                        setEditingAccountId(null);
+                      }}
+                      onKeyDown={async (e) => {
+                        if (e.key === 'Enter') {
+                          if (editAccountName.trim() && editAccountName !== currentAcc?.label) {
+                            await vault.renameAccount(selectedAccountIndex, editAccountName.trim());
+                          }
+                          setEditingAccountId(null);
+                        } else if (e.key === 'Escape') {
+                          setEditingAccountId(null);
+                        }
+                      }}
+                      className="bg-xmr-base border border-xmr-green text-xmr-green text-sm font-black p-1 uppercase outline-none mt-0.5 w-48"
+                    />
+                  ) : (
+                    <div className="text-sm font-black uppercase tracking-[0.15em] text-xmr-green mt-0.5">
                       {currentAcc?.label || 'UNTITLED_IDENTITY'}
-                    </span>
-                  </div>
-                  <span className="text-xs text-xmr-dim font-black opacity-50 group-hover:text-xmr-green transition-colors ml-4">▼</span>
+                    </div>
+                  )}
+                </div>
+
+                {/* Three-dot menu */}
+                <div className="relative" ref={cardMenuRef}>
+                  <button
+                    onClick={(e) => { e.stopPropagation(); setShowCardMenu(!showCardMenu); }}
+                    className="w-7 h-7 flex items-center justify-center border border-xmr-border/20 rounded-md text-xmr-dim hover:text-xmr-green hover:border-xmr-green/50 hover:bg-xmr-green/10 transition-all cursor-pointer"
+                  >
+                    <MoreVertical size={14} />
+                  </button>
+                  {showCardMenu && (
+                    <div className="absolute right-0 top-9 bg-xmr-base border border-xmr-border/50 rounded-md shadow-xl z-50 min-w-[180px] py-1 animate-in fade-in zoom-in-95 duration-150">
+                      <button
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          setEditAccountName(currentAcc?.label || '');
+                          setEditingAccountId(selectedAccountIndex);
+                          setShowCardMenu(false);
+                        }}
+                        className="w-full px-4 py-2.5 text-left text-[11px] font-black uppercase tracking-widest text-xmr-dim hover:text-xmr-green hover:bg-xmr-green/10 transition-all flex items-center gap-2 cursor-pointer"
+                      >
+                        <Edit2 size={10} /> Rename
+                      </button>
+                      <button
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          handleOpenCreateModal();
+                          setShowCardMenu(false);
+                        }}
+                        className="w-full px-4 py-2.5 text-left text-[11px] font-black uppercase tracking-widest text-xmr-accent hover:bg-xmr-accent/10 transition-all flex items-center gap-2 cursor-pointer"
+                      >
+                        <Plus size={10} /> New Account
+                      </button>
+                    </div>
+                  )}
                 </div>
               </div>
 
-              <div className="flex flex-col mt-6">
-                <div className="text-5xl font-black text-xmr-green leading-none">
-                  {currentAccBalance}
-                  <span className="text-xl text-xmr-dim uppercase ml-3">XMR</span>
+              {/* Balance */}
+              <div className="flex flex-col gap-0.5 relative z-10">
+                <div className="flex items-baseline gap-2.5">
+                  <span className="text-4xl font-black text-xmr-green leading-none">{currentAccBalance}</span>
+                  <span className="text-base text-xmr-dim font-bold">XMR</span>
                 </div>
                 {usdValue && (
-                  <div className="text-sm font-black text-xmr-dim uppercase tracking-widest mt-2 px-1">
+                  <div className="text-xs font-bold text-xmr-dim/60 uppercase tracking-[0.1em]">
                     {usdValue} USD
                   </div>
                 )}
               </div>
-            </div>
-          </div>
-          <div className="flex gap-12 border-t border-xmr-border/20 pt-6 uppercase font-black">
-            <div><span className="text-xs font-black text-xmr-dim uppercase">Unlocked</span><div className="text-2xl font-black text-xmr-green">{parseFloat(currentAcc?.unlockedBalance || '0').toFixed(4)}</div></div>
-            <div><span className="text-xs font-black text-xmr-dim uppercase">Active_Outputs</span><div className="text-2xl font-black opacity-40 text-xmr-green">{outputs?.length || 0}</div></div>
-          </div>
-        </Card>
 
-        <div className="flex flex-col gap-6 font-black">
-          <Card className="flex-grow flex flex-col justify-between p-4!">
-            <div className="flex justify-between items-start font-black">
-              <span className="text-xs text-xmr-dim uppercase tracking-widest font-black">Identity_Status</span>
-              <button onClick={revealSeed} className="text-xmr-green hover:text-xmr-accent transition-all cursor-pointer">
-                <Key size={16} />
-              </button>
-            </div>
-            <div className="p-3 bg-xmr-base border border-xmr-border/30 rounded-sm font-black overflow-hidden">
-              <div className="flex justify-between items-center mb-1 font-black"><span className="text-xs opacity-50 text-xmr-green font-black uppercase">SESSION_ADDRESS</span></div>
-              <AddressDisplay address={address} className="text-[11px] " />
-            </div>
-            <div className="space-y-1.5 border-t border-xmr-border/20 pt-4 font-black">
-              <div className="flex justify-between text-[11px] uppercase font-black">
-                <span className="opacity-40 text-xmr-green">Uplink:</span>
-                <span className={`font-black flex items-center gap-1.5 ${isSyncing ? 'text-xmr-accent animate-pulse' : 'text-xmr-green'}`}>
-                  {isSyncing && <Loader2 size={10} className="animate-spin" />}
-                  {status}
-                </span>
+              {/* Card footer */}
+              <div className="flex justify-between items-end relative z-10">
+                <div className="text-[10px] text-xmr-dim/30 tracking-wider">
+                  {currentAcc?.baseAddress?.substring(0, 8)}...{currentAcc?.baseAddress?.substring((currentAcc?.baseAddress?.length || 8) - 6)}
+                </div>
+                {/* Dot indicators */}
+                <div className="flex gap-1.5" onClick={(e) => e.stopPropagation()}>
+                  {accounts.map(acc => (
+                    <button
+                      key={acc.index}
+                      onClick={() => setSelectedAccountIndex(acc.index)}
+                      className={`w-[7px] h-[7px] rounded-full transition-all cursor-pointer ${acc.index === selectedAccountIndex
+                        ? 'bg-xmr-green shadow-[0_0_8px_var(--color-xmr-green)]'
+                        : 'bg-xmr-green/30 hover:bg-xmr-green/60'
+                      }`}
+                      title={acc.label || `Account ${acc.index}`}
+                    />
+                  ))}
+                </div>
               </div>
-              <div className="flex justify-between text-[11px] uppercase font-black"><span className="opacity-40 text-xmr-green">Height:</span><span className="text-xmr-green">{currentHeight || '---'}</span></div>
             </div>
-          </Card>
-          <div className="grid grid-cols-2 gap-4 font-black">
-            <button disabled={isSyncing} onClick={() => setModals(prev => ({ ...prev, receive: true }))} className="py-4 border border-xmr-green text-xmr-green font-black uppercase text-xs tracking-widest hover:bg-xmr-green hover:text-xmr-base transition-all flex items-center justify-center gap-2 cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"><Download size={16} /> Receive</button>
-            <button disabled={isSyncing} onClick={() => setModals(prev => ({ ...prev, send: true }))} className="py-4 border border-xmr-accent text-xmr-accent font-black uppercase text-xs tracking-widest hover:bg-xmr-accent hover:text-xmr-base transition-all flex items-center justify-center gap-2 cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"><Send size={16} /> Dispatch</button>
+          </div>
+
+          {/* Quick Actions Row */}
+          <div className="flex gap-3 justify-center">
+            {quickActions.map(action => (
+              <button
+                key={action.label}
+                onClick={action.onClick}
+                disabled={action.disabled}
+                className="flex flex-col items-center gap-1.5 group cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed"
+              >
+                <div className="w-[52px] h-[52px] rounded-full border border-xmr-green/30 flex items-center justify-center bg-xmr-base text-xmr-green group-hover:border-xmr-green/80 group-hover:bg-xmr-green/10 group-hover:scale-105 transition-all disabled:group-hover:scale-100">
+                  <action.icon size={18} className={action.spin ? 'animate-spin' : ''} />
+                </div>
+                <span className="text-[9px] font-black uppercase tracking-[0.15em] text-xmr-dim group-hover:text-xmr-green transition-colors">
+                  {action.label}
+                </span>
+              </button>
+            ))}
           </div>
         </div>
+
+        {/* RIGHT: Identity Status (enhanced with Unlocked + Outputs) */}
+        <Card className="flex flex-col justify-between p-4! h-fit">
+          <div className="flex justify-between items-start font-black">
+            <span className="text-xs text-xmr-dim uppercase tracking-widest font-black">Identity_Status</span>
+            <button onClick={revealSeed} className="text-xmr-green hover:text-xmr-accent transition-all cursor-pointer">
+              <Key size={16} />
+            </button>
+          </div>
+          <div className="p-3 bg-xmr-base border border-xmr-border/30 rounded-sm font-black overflow-hidden mt-3">
+            <div className="flex justify-between items-center mb-1 font-black"><span className="text-xs opacity-50 text-xmr-green font-black uppercase">SESSION_ADDRESS</span></div>
+            <AddressDisplay address={address} className="text-[11px] " />
+          </div>
+          <div className="space-y-1.5 border-t border-xmr-border/20 pt-4 mt-3 font-black">
+            <div className="flex justify-between text-[11px] uppercase font-black">
+              <span className="opacity-40 text-xmr-green">Uplink:</span>
+              <span className={`font-black flex items-center gap-1.5 ${isSyncing ? 'text-xmr-accent animate-pulse' : 'text-xmr-green'}`}>
+                {isSyncing && <Loader2 size={10} className="animate-spin" />}
+                {status}
+              </span>
+            </div>
+            <div className="flex justify-between text-[11px] uppercase font-black"><span className="opacity-40 text-xmr-green">Height:</span><span className="text-xmr-green">{currentHeight || '---'}</span></div>
+            <div className="flex justify-between text-[11px] uppercase font-black"><span className="opacity-40 text-xmr-green">Unlocked:</span><span className="text-xmr-green">{parseFloat(currentAcc?.unlockedBalance || '0').toFixed(4)}</span></div>
+            <div className="flex justify-between text-[11px] uppercase font-black"><span className="opacity-40 text-xmr-green">Outputs:</span><span className="text-xmr-green">{outputs?.length || 0}</span></div>
+          </div>
+        </Card>
       </div>
 
       {/* 3. TABS NAVIGATION */}
@@ -308,109 +423,6 @@ export function VaultView({ setView, vault, handleBurn, appConfig }: VaultViewPr
         onChurn={churn}
         unlockedBalance={parseFloat(currentAcc?.unlockedBalance || '0')}
       />
-
-      {/* 6. ACCOUNT SELECTOR DRAWER */}
-      {showAccountDropdown && (
-        <div className="fixed inset-0 z-50 flex justify-end bg-black/50 backdrop-blur-sm animate-in fade-in duration-200">
-          <div
-            ref={dropdownRef}
-            className="w-[450px] max-w-[90vw] h-full bg-xmr-base border-l border-xmr-border/50 shadow-2xl flex flex-col font-mono animate-in slide-in-from-right duration-300"
-          >
-            <div className="flex justify-between items-center p-6 border-b border-xmr-border/20 relative">
-              <h3 className="text-lg font-black uppercase text-xmr-green tracking-widest">Account_Manager</h3>
-              <button
-                onClick={() => setShowAccountDropdown(false)}
-                className="text-xmr-dim hover:text-xmr-green cursor-pointer"
-              >
-                ✕
-              </button>
-            </div>
-
-            <div className="flex px-6 py-3 border-b border-xmr-border/20 text-[11px] uppercase font-black text-xmr-dim tracking-widest bg-xmr-base">
-              <div className="w-12">IDX</div>
-              <div className="flex-1">Identity & Address</div>
-              <div className="w-24 text-right">Balance</div>
-            </div>
-
-            <div className="flex-1 overflow-y-auto">
-              {accounts.map(acc => (
-                <div
-                  key={acc.index}
-                  className={`flex items-center px-6 py-4 border-b border-xmr-border/10 cursor-pointer hover:bg-xmr-green/10 transition-colors group ${acc.index === selectedAccountIndex ? 'bg-xmr-green/5' : ''}`}
-                  onClick={() => {
-                    setSelectedAccountIndex(acc.index);
-                    setShowAccountDropdown(false);
-                  }}
-                >
-                  <div className="w-12 text-xs text-xmr-dim font-black flex items-center h-full pt-1">
-                    {acc.index.toString().padStart(2, '0')}
-                  </div>
-                  <div className="flex-1 flex flex-col justify-center pr-4">
-                    {editingAccountId === acc.index ? (
-                      <input
-                        autoFocus
-                        value={editAccountName}
-                        onClick={(e) => e.stopPropagation()}
-                        onChange={(e) => setEditAccountName(e.target.value)}
-                        onBlur={async () => {
-                          if (editAccountName.trim() && editAccountName !== acc.label) {
-                            await vault.renameAccount(acc.index, editAccountName.trim());
-                          }
-                          setEditingAccountId(null);
-                        }}
-                        onKeyDown={async (e) => {
-                          if (e.key === 'Enter') {
-                            if (editAccountName.trim() && editAccountName !== acc.label) {
-                              await vault.renameAccount(acc.index, editAccountName.trim());
-                            }
-                            setEditingAccountId(null);
-                          } else if (e.key === 'Escape') {
-                            setEditingAccountId(null);
-                          }
-                        }}
-                        className="bg-xmr-base border border-xmr-green text-xmr-green text-xs font-black p-1 uppercase outline-none mb-0.5 w-full"
-                      />
-                    ) : (
-                      <div className="flex items-center gap-2 mb-0.5 group/edit">
-                        <span className="text-xs text-xmr-green break-all font-black uppercase">
-                          {acc.label || 'UNTITLED'}
-                        </span>
-                        <button
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            setEditAccountName(acc.label || '');
-                            setEditingAccountId(acc.index);
-                          }}
-                          className="opacity-0 group-hover/edit:opacity-100 text-xmr-dim hover:text-xmr-accent transition-all cursor-pointer"
-                        >
-                          <Edit2 size={10} />
-                        </button>
-                      </div>
-                    )}
-                    <span className="text-xs text-xmr-dim font-black tracking-widest opacity-60">
-                      {acc.baseAddress?.substring(0, 16)}...{acc.baseAddress?.substring(acc.baseAddress.length - 8)}
-                    </span>
-                  </div>
-                  <div className="w-24 text-right flex flex-col justify-center items-end">
-                    <span className="text-sm text-xmr-green font-black">{parseFloat(acc.balance).toFixed(4)}</span>
-                    <span className="text-[11px] text-xmr-dim font-black uppercase mt-0.5">XMR</span>
-                  </div>
-                </div>
-              ))}
-            </div>
-
-            <div
-              onClick={() => {
-                handleOpenCreateModal();
-                setShowAccountDropdown(false);
-              }}
-              className="p-6 text-center text-xs text-xmr-accent hover:bg-xmr-accent/10 border-t border-xmr-border/50 cursor-pointer font-black uppercase transition-colors"
-            >
-              + Generate New Account
-            </div>
-          </div>
-        </div>
-      )}
     </div>
   );
 }

--- a/src/renderer/components/VaultView.tsx
+++ b/src/renderer/components/VaultView.tsx
@@ -5,6 +5,8 @@ import { AddressList } from './vault/AddressList';
 import { CoinControl } from './vault/CoinControl';
 import { TransactionLedger } from './vault/TransactionLedger';
 import { VaultModals } from './vault/VaultModals';
+import { DispatchModal } from './vault/DispatchModal';
+import { ReceiveModal } from './vault/ReceiveModal';
 import { type VaultContextType } from '../contexts/VaultContext';
 import { WalletService } from '../services/walletService';
 import { useFiatValue } from '../hooks/useFiatValue';
@@ -37,6 +39,7 @@ export function VaultView({ setView, vault, handleBurn, appConfig }: VaultViewPr
   const [editAccountName, setEditAccountName] = useState('');
   const [hideZeroBalances, setHideZeroBalances] = useState(false);
   const [switching, setSwitching] = useState(false);
+  const [activePanel, setActivePanel] = useState<'send' | 'receive' | null>(null);
 
   const currentAcc = accounts.find(a => a.index === selectedAccountIndex);
   const currentAccBalance = currentAcc?.balance || '0.0000';
@@ -55,8 +58,8 @@ export function VaultView({ setView, vault, handleBurn, appConfig }: VaultViewPr
   const accountListRef = useRef<HTMLDivElement>(null);
   useEffect(() => {
     if (requestedAction) {
-      if (requestedAction === 'OPEN_SEND') setModals(prev => ({ ...prev, send: true }));
-      else if (requestedAction === 'OPEN_RECEIVE') setModals(prev => ({ ...prev, receive: true }));
+      if (requestedAction === 'OPEN_SEND') setActivePanel('send');
+      else if (requestedAction === 'OPEN_RECEIVE') setActivePanel('receive');
       else if (requestedAction === 'OPEN_CHURN') setModals(prev => ({ ...prev, churn: true }));
       else if (requestedAction === 'OPEN_SPLINTER') setModals(prev => ({ ...prev, splinter: true }));
       vault.setRequestedAction(null);
@@ -159,8 +162,8 @@ export function VaultView({ setView, vault, handleBurn, appConfig }: VaultViewPr
   const { fiatText: totalFiat } = useFiatValue('XMR', totalBalance.toFixed(12), true);
 
   const quickActions = [
-    { label: 'Dispatch', icon: Send, onClick: () => setModals(prev => ({ ...prev, send: true })), disabled: isHeavySync },
-    { label: 'Receive', icon: Download, onClick: () => setModals(prev => ({ ...prev, receive: true })), disabled: isHeavySync },
+    { label: 'Dispatch', icon: Send, onClick: () => setActivePanel('send'), disabled: isHeavySync },
+    { label: 'Receive', icon: Download, onClick: () => setActivePanel('receive'), disabled: isHeavySync },
     { label: 'Churn', icon: Wind, onClick: () => setModals(prev => ({ ...prev, churn: true })), disabled: isHeavySync || isSending || hasNoBalance },
     { label: 'Splinter', icon: Scissors, onClick: () => setModals(prev => ({ ...prev, splinter: true })), disabled: isHeavySync || isSending || hasNoBalance },
     { label: 'Sync', icon: RefreshCw, onClick: refresh, disabled: false, spin: isSyncing || isSending },
@@ -410,44 +413,61 @@ export function VaultView({ setView, vault, handleBurn, appConfig }: VaultViewPr
 
       </div>
 
-      {/* 3. TABS + CONTENT */}
+      {/* 3. TABS + CONTENT (or inline Send/Receive panel) */}
       <div className="min-h-[400px] border border-xmr-border/20 rounded-lg overflow-hidden bg-xmr-surface/30">
-        {/* Tab bar — inside the content border */}
-        <div className="flex gap-1 items-center px-3 py-2 border-b border-xmr-border/15 bg-xmr-surface/50">
-          {['ledger', 'coins', 'addresses', 'contacts'].map((t) => (
-            <button
-              key={t}
-              onClick={() => setTab(t as any)}
-              className={`px-4 py-2 text-[11px] font-black uppercase tracking-widest transition-all rounded-lg ${tab === t ? 'text-xmr-green border border-xmr-green/30 bg-xmr-green/5' : 'text-xmr-dim hover:text-xmr-green border border-transparent'}`}
-            >
-              {t}
-            </button>
-          ))}
-        </div>
+        {activePanel === 'send' ? (
+          <DispatchModal
+            inline
+            onClose={() => { setActivePanel(null); setDispatchSubIndex(undefined); }}
+            initialAddress={dispatchAddr}
+            sourceSubaddressIndex={dispatchSubIndex}
+          />
+        ) : activePanel === 'receive' ? (
+          <ReceiveModal
+            inline
+            onClose={() => { setActivePanel(null); setSelectedSubaddress(null); }}
+            existingAddress={selectedSubaddress || undefined}
+          />
+        ) : (
+          <>
+            {/* Tab bar */}
+            <div className="flex gap-1 items-center px-3 py-2 border-b border-xmr-border/15 bg-xmr-surface/50">
+              {['ledger', 'coins', 'addresses', 'contacts'].map((t) => (
+                <button
+                  key={t}
+                  onClick={() => setTab(t as any)}
+                  className={`px-4 py-2 text-[11px] font-black uppercase tracking-widest transition-all rounded-lg ${tab === t ? 'text-xmr-green border border-xmr-green/30 bg-xmr-green/5' : 'text-xmr-dim hover:text-xmr-green border border-transparent'}`}
+                >
+                  {t}
+                </button>
+              ))}
+            </div>
 
-        {/* Tab content */}
-        <div>
-        {tab === 'ledger' && <TransactionLedger txs={txs} subaddresses={subaddresses} />}
-        {tab === 'coins' && <CoinControl outputs={outputs} onSendFromCoin={(_keyImage, _amount) => { setModals(prev => ({ ...prev, send: true })); }} />}
-        {tab === 'addresses' && <AddressList
-          subaddresses={hideZeroBalances ? subaddresses.filter(s => parseFloat(s.balance) > 0 || s.index === 0) : subaddresses}
-          handleCopy={handleCopy}
-          onUpdateLabel={setSubaddressLabel}
-          onRowClick={(s) => { setSelectedSubaddress(s); setModals(prev => ({ ...prev, receive: true })); }}
-          onVanishSubaddress={vanishSubaddress}
-          onSendFrom={(idx) => { setDispatchSubIndex(idx); setModals(prev => ({ ...prev, send: true })); }}
-          isSyncing={status === 'SYNCING'}
-          hideZeroBalances={hideZeroBalances}
-          onToggleFilter={handleToggleFilter}
-        />}
-        {tab === 'contacts' && <AddressBook
-          contacts={contacts}
-          onAddContact={(c) => saveContacts([...contacts, c])}
-          onRemoveContact={(idx) => saveContacts(contacts.filter((_, i) => i !== idx))}
-          onDispatch={(addr) => { setDispatchAddr(addr); setModals(prev => ({ ...prev, send: true })); }}
-          handleCopy={handleCopy}
-        />}
-        </div>
+            {/* Tab content */}
+            <div>
+              {tab === 'ledger' && <TransactionLedger txs={txs} subaddresses={subaddresses} />}
+              {tab === 'coins' && <CoinControl outputs={outputs} onSendFromCoin={(_keyImage, _amount) => { setActivePanel('send'); }} />}
+              {tab === 'addresses' && <AddressList
+                subaddresses={hideZeroBalances ? subaddresses.filter(s => parseFloat(s.balance) > 0 || s.index === 0) : subaddresses}
+                handleCopy={handleCopy}
+                onUpdateLabel={setSubaddressLabel}
+                onRowClick={(s) => { setSelectedSubaddress(s); setActivePanel('receive'); }}
+                onVanishSubaddress={vanishSubaddress}
+                onSendFrom={(idx) => { setDispatchSubIndex(idx); setActivePanel('send'); }}
+                isSyncing={status === 'SYNCING'}
+                hideZeroBalances={hideZeroBalances}
+                onToggleFilter={handleToggleFilter}
+              />}
+              {tab === 'contacts' && <AddressBook
+                contacts={contacts}
+                onAddContact={(c) => saveContacts([...contacts, c])}
+                onRemoveContact={(idx) => saveContacts(contacts.filter((_, i) => i !== idx))}
+                onDispatch={(addr) => { setDispatchAddr(addr); setActivePanel('send'); }}
+                handleCopy={handleCopy}
+              />}
+            </div>
+          </>
+        )}
       </div>
 
       {/* 5. MODALS */}

--- a/src/renderer/components/VaultView.tsx
+++ b/src/renderer/components/VaultView.tsx
@@ -1,13 +1,11 @@
 import React, { useState, useEffect, useRef } from 'react';
-import { RefreshCw, Key, Send, Download, Wind, Loader2, Edit2, Scissors, MoreVertical, Plus } from 'lucide-react';
-import { Card } from './Card';
+import { RefreshCw, Key, Send, Download, Wind, Loader2, Edit2, Scissors, MoreVertical, Plus, ChevronLeft, ChevronRight } from 'lucide-react';
 import { AddressBook } from './vault/AddressBook';
 import { AddressList } from './vault/AddressList';
 import { CoinControl } from './vault/CoinControl';
 import { TransactionLedger } from './vault/TransactionLedger';
 import { VaultModals } from './vault/VaultModals';
 import { type VaultContextType } from '../contexts/VaultContext';
-import { AddressDisplay } from './common/AddressDisplay';
 import { WalletService } from '../services/walletService';
 import { useFiatValue } from '../hooks/useFiatValue';
 
@@ -34,6 +32,7 @@ export function VaultView({ setView, vault, handleBurn, appConfig }: VaultViewPr
   const [selectedSubaddress, setSelectedSubaddress] = useState<any>(null);
   const [dispatchSubIndex, setDispatchSubIndex] = useState<number | undefined>(undefined);
   const [showCardMenu, setShowCardMenu] = useState(false);
+  const [showAccountList, setShowAccountList] = useState(false);
   const [editingAccountId, setEditingAccountId] = useState<number | null>(null);
   const [editAccountName, setEditAccountName] = useState('');
   const [hideZeroBalances, setHideZeroBalances] = useState(false);
@@ -53,6 +52,7 @@ export function VaultView({ setView, vault, handleBurn, appConfig }: VaultViewPr
   }, [activeId, appConfig]);
 
   const cardMenuRef = useRef<HTMLDivElement>(null);
+  const accountListRef = useRef<HTMLDivElement>(null);
   useEffect(() => {
     if (requestedAction) {
       if (requestedAction === 'OPEN_SEND') setModals(prev => ({ ...prev, send: true }));
@@ -67,6 +67,9 @@ export function VaultView({ setView, vault, handleBurn, appConfig }: VaultViewPr
     function handleClickOutside(event: MouseEvent) {
       if (cardMenuRef.current && !cardMenuRef.current.contains(event.target as Node)) {
         setShowCardMenu(false);
+      }
+      if (accountListRef.current && !accountListRef.current.contains(event.target as Node)) {
+        setShowAccountList(false);
       }
     }
     document.addEventListener("mousedown", handleClickOutside);
@@ -135,14 +138,22 @@ export function VaultView({ setView, vault, handleBurn, appConfig }: VaultViewPr
   const isSyncing = status === 'SYNCING' || status === 'READY';
   const isFullySynced = status === 'SYNCED';
 
-  const cycleAccount = () => {
+  const currentAccIdx = accounts.findIndex(a => a.index === selectedAccountIndex);
+  const prevAccount = () => {
     if (accounts.length <= 1) return;
-    const currentIdx = accounts.findIndex(a => a.index === selectedAccountIndex);
-    const nextIdx = (currentIdx + 1) % accounts.length;
+    const prevIdx = (currentAccIdx - 1 + accounts.length) % accounts.length;
+    setSelectedAccountIndex(accounts[prevIdx].index);
+  };
+  const nextAccount = () => {
+    if (accounts.length <= 1) return;
+    const nextIdx = (currentAccIdx + 1) % accounts.length;
     setSelectedAccountIndex(accounts[nextIdx].index);
   };
 
   const hasNoBalance = parseFloat(currentAcc?.unlockedBalance || '0') <= 0;
+  const totalBalance = accounts.reduce((sum, acc) => sum + parseFloat(acc.balance || '0'), 0);
+  const totalUnlocked = accounts.reduce((sum, acc) => sum + parseFloat(acc.unlockedBalance || '0'), 0);
+  const { fiatText: totalFiat } = useFiatValue('XMR', totalBalance.toFixed(12), true);
 
   const quickActions = [
     { label: 'Dispatch', icon: Send, onClick: () => setModals(prev => ({ ...prev, send: true })), disabled: isSyncing },
@@ -175,192 +186,234 @@ export function VaultView({ setView, vault, handleBurn, appConfig }: VaultViewPr
         </div>
       )}
 
-      {/* 2. CARD STACK + IDENTITY STATUS */}
-      <div className="grid grid-cols-1 lg:grid-cols-[2fr_1fr] gap-6 relative z-10 font-black font-mono">
+      {/* 2. ACCOUNT CARD + QUICK ACTIONS */}
+      <div className="relative z-10 font-black font-mono space-y-4">
 
-        {/* LEFT: Card Stack + Quick Actions */}
-        <div className="flex flex-col gap-5">
+        {/* Full-width account card */}
+        <div className="relative" style={{ perspective: '800px' }}>
+          {/* Background cards (stack effect) */}
+          {accounts.length >= 3 && (
+            <div className="absolute top-0 left-8 right-8 h-full bg-xmr-surface border border-xmr-border/15 rounded-lg" style={{ transform: 'translateY(-6px) scale(0.96)', opacity: 0.25 }} />
+          )}
+          {accounts.length >= 2 && (
+            <div className="absolute top-0 left-4 right-4 h-full bg-xmr-surface border border-xmr-border/20 rounded-lg" style={{ transform: 'translateY(-3px) scale(0.98)', opacity: 0.4 }} />
+          )}
 
-          {/* Card Stack */}
-          <div className="relative h-[220px] cursor-pointer" style={{ perspective: '800px' }} onClick={cycleAccount}>
-            {/* Background card 3 (deepest) */}
-            {accounts.length >= 3 && (
-              <div
-                className="absolute top-0 left-6 right-6 h-[200px] bg-xmr-surface border border-xmr-border/15 rounded-lg"
-                style={{ transform: 'translateY(0px) scale(0.92)', opacity: 0.3 }}
-              />
-            )}
-            {/* Background card 2 */}
-            {accounts.length >= 2 && (
-              <div
-                className="absolute top-0 left-3.5 right-3.5 h-[200px] bg-xmr-surface border border-xmr-border/20 rounded-lg"
-                style={{ transform: 'translateY(6px) scale(0.96)', opacity: 0.5 }}
-              />
-            )}
+          {/* Main card */}
+          <div className={`relative bg-gradient-to-br from-xmr-green/5 via-xmr-green/8 to-xmr-green/3 bg-xmr-surface border border-xmr-green/40 rounded-lg shadow-[0_8px_32px_rgba(0,0,0,0.5)] transition-all duration-150 ${switching ? 'opacity-70 scale-[0.99]' : 'opacity-100 scale-100'}`}>
+            {/* Top glow */}
+            <div className="absolute top-0 left-0 right-0 h-[2px] bg-gradient-to-r from-transparent via-xmr-green/50 to-transparent rounded-t-lg" />
+            {/* Watermark */}
+            <div className="absolute right-6 bottom-3 text-8xl font-black text-xmr-green/[0.03] tracking-tighter select-none pointer-events-none">XMR</div>
 
-            {/* Main card (active account) */}
-            <div
-              className={`absolute top-0 left-0 right-0 h-[200px] bg-gradient-to-br from-xmr-green/5 via-xmr-green/8 to-xmr-green/3 bg-xmr-surface border border-xmr-green/40 rounded-lg p-6 flex flex-col justify-between shadow-[0_8px_32px_rgba(0,0,0,0.5)] transition-all duration-150 ${switching ? 'scale-[0.97] opacity-70' : 'scale-100 opacity-100'}`}
-              style={{ transform: `translateY(14px) ${switching ? 'scale(0.97)' : 'scale(1)'}` }}
-            >
-              {/* Top glow */}
-              <div className="absolute top-0 left-0 right-0 h-[2px] bg-gradient-to-r from-transparent via-xmr-green/50 to-transparent rounded-t-lg" />
-
-              {/* Watermark */}
-              <div className="absolute right-5 bottom-4 text-7xl font-black text-xmr-green/5 tracking-tighter select-none pointer-events-none">XMR</div>
-
-              {/* Card header */}
-              <div className="flex justify-between items-start relative z-10">
-                <div>
-                  <div className="text-[11px] text-xmr-dim font-bold tracking-[0.2em] uppercase">ACCT #{String(selectedAccountIndex).padStart(2, '0')}</div>
-                  {editingAccountId === selectedAccountIndex ? (
-                    <input
-                      autoFocus
-                      value={editAccountName}
-                      onClick={(e) => e.stopPropagation()}
-                      onChange={(e) => setEditAccountName(e.target.value)}
-                      onBlur={async () => {
-                        if (editAccountName.trim() && editAccountName !== currentAcc?.label) {
-                          await vault.renameAccount(selectedAccountIndex, editAccountName.trim());
-                        }
-                        setEditingAccountId(null);
-                      }}
-                      onKeyDown={async (e) => {
-                        if (e.key === 'Enter') {
+            {/* Card content: 2-column layout inside */}
+            <div className="flex relative z-10">
+              {/* Left: account info + balance */}
+              <div className="flex-1 p-6 pr-0">
+                {/* Header row */}
+                <div className="flex items-start gap-3 mb-4">
+                  {/* Prev arrow */}
+                  {accounts.length > 1 && (
+                    <button onClick={prevAccount} className="mt-0.5 w-7 h-7 flex items-center justify-center rounded-full border border-xmr-border/30 text-xmr-dim hover:text-xmr-green hover:border-xmr-green/50 hover:bg-xmr-green/10 transition-all cursor-pointer shrink-0">
+                      <ChevronLeft size={14} />
+                    </button>
+                  )}
+                  <div className="min-w-0 flex-1">
+                    <div className="text-[11px] text-xmr-dim font-bold tracking-[0.2em] uppercase">ACCT #{String(selectedAccountIndex).padStart(2, '0')}</div>
+                    {editingAccountId === selectedAccountIndex ? (
+                      <input
+                        autoFocus
+                        value={editAccountName}
+                        onChange={(e) => setEditAccountName(e.target.value)}
+                        onBlur={async () => {
                           if (editAccountName.trim() && editAccountName !== currentAcc?.label) {
                             await vault.renameAccount(selectedAccountIndex, editAccountName.trim());
                           }
                           setEditingAccountId(null);
-                        } else if (e.key === 'Escape') {
-                          setEditingAccountId(null);
-                        }
-                      }}
-                      className="bg-xmr-base border border-xmr-green text-xmr-green text-sm font-black p-1 uppercase outline-none mt-0.5 w-48"
-                    />
-                  ) : (
-                    <div className="text-sm font-black uppercase tracking-[0.15em] text-xmr-green mt-0.5">
-                      {currentAcc?.label || 'UNTITLED_IDENTITY'}
-                    </div>
+                        }}
+                        onKeyDown={async (e) => {
+                          if (e.key === 'Enter') {
+                            if (editAccountName.trim() && editAccountName !== currentAcc?.label) {
+                              await vault.renameAccount(selectedAccountIndex, editAccountName.trim());
+                            }
+                            setEditingAccountId(null);
+                          } else if (e.key === 'Escape') {
+                            setEditingAccountId(null);
+                          }
+                        }}
+                        className="bg-xmr-base border border-xmr-green text-xmr-green text-sm font-black p-1 uppercase outline-none mt-0.5 w-48"
+                      />
+                    ) : (
+                      <div className="text-base font-black uppercase tracking-[0.15em] text-xmr-green mt-0.5 truncate">
+                        {currentAcc?.label || 'UNTITLED_ACCOUNT'}
+                      </div>
+                    )}
+                  </div>
+                  {/* Next arrow */}
+                  {accounts.length > 1 && (
+                    <button onClick={nextAccount} className="mt-0.5 w-7 h-7 flex items-center justify-center rounded-full border border-xmr-border/30 text-xmr-dim hover:text-xmr-green hover:border-xmr-green/50 hover:bg-xmr-green/10 transition-all cursor-pointer shrink-0">
+                      <ChevronRight size={14} />
+                    </button>
                   )}
+                  {/* Three-dot menu */}
+                  <div className="relative shrink-0" ref={cardMenuRef}>
+                    <button
+                      onClick={() => setShowCardMenu(!showCardMenu)}
+                      className="w-7 h-7 flex items-center justify-center border border-xmr-border/20 rounded-md text-xmr-dim hover:text-xmr-green hover:border-xmr-green/50 hover:bg-xmr-green/10 transition-all cursor-pointer"
+                    >
+                      <MoreVertical size={14} />
+                    </button>
+                    {showCardMenu && (
+                      <div className="absolute right-0 top-9 bg-xmr-base border border-xmr-border/50 rounded-md shadow-xl z-50 min-w-[180px] py-1 animate-in fade-in zoom-in-95 duration-150">
+                        <button
+                          onClick={() => { setEditAccountName(currentAcc?.label || ''); setEditingAccountId(selectedAccountIndex); setShowCardMenu(false); }}
+                          className="w-full px-4 py-2.5 text-left text-[11px] font-black uppercase tracking-widest text-xmr-dim hover:text-xmr-green hover:bg-xmr-green/10 transition-all flex items-center gap-2 cursor-pointer"
+                        >
+                          <Edit2 size={10} /> Rename
+                        </button>
+                        <button
+                          onClick={() => { handleOpenCreateModal(); setShowCardMenu(false); }}
+                          className="w-full px-4 py-2.5 text-left text-[11px] font-black uppercase tracking-widest text-xmr-accent hover:bg-xmr-accent/10 transition-all flex items-center gap-2 cursor-pointer"
+                        >
+                          <Plus size={10} /> New Account
+                        </button>
+                        <div className="border-t border-xmr-border/20 my-1" />
+                        <button
+                          onClick={() => { revealSeed(); setShowCardMenu(false); }}
+                          className="w-full px-4 py-2.5 text-left text-[11px] font-black uppercase tracking-widest text-xmr-dim hover:text-xmr-accent hover:bg-xmr-accent/10 transition-all flex items-center gap-2 cursor-pointer"
+                        >
+                          <Key size={10} /> Backup Seed
+                        </button>
+                      </div>
+                    )}
+                  </div>
                 </div>
 
-                {/* Three-dot menu */}
-                <div className="relative" ref={cardMenuRef}>
-                  <button
-                    onClick={(e) => { e.stopPropagation(); setShowCardMenu(!showCardMenu); }}
-                    className="w-7 h-7 flex items-center justify-center border border-xmr-border/20 rounded-md text-xmr-dim hover:text-xmr-green hover:border-xmr-green/50 hover:bg-xmr-green/10 transition-all cursor-pointer"
-                  >
-                    <MoreVertical size={14} />
-                  </button>
-                  {showCardMenu && (
-                    <div className="absolute right-0 top-9 bg-xmr-base border border-xmr-border/50 rounded-md shadow-xl z-50 min-w-[180px] py-1 animate-in fade-in zoom-in-95 duration-150">
-                      <button
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          setEditAccountName(currentAcc?.label || '');
-                          setEditingAccountId(selectedAccountIndex);
-                          setShowCardMenu(false);
-                        }}
-                        className="w-full px-4 py-2.5 text-left text-[11px] font-black uppercase tracking-widest text-xmr-dim hover:text-xmr-green hover:bg-xmr-green/10 transition-all flex items-center gap-2 cursor-pointer"
-                      >
-                        <Edit2 size={10} /> Rename
-                      </button>
-                      <button
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          handleOpenCreateModal();
-                          setShowCardMenu(false);
-                        }}
-                        className="w-full px-4 py-2.5 text-left text-[11px] font-black uppercase tracking-widest text-xmr-accent hover:bg-xmr-accent/10 transition-all flex items-center gap-2 cursor-pointer"
-                      >
-                        <Plus size={10} /> New Account
-                      </button>
-                    </div>
-                  )}
-                </div>
-              </div>
-
-              {/* Balance */}
-              <div className="flex flex-col gap-0.5 relative z-10">
-                <div className="flex items-baseline gap-2.5">
+                {/* Balance */}
+                <div className="flex items-baseline gap-2.5 mb-1">
                   <span className="text-4xl font-black text-xmr-green leading-none">{currentAccBalance}</span>
                   <span className="text-base text-xmr-dim font-bold">XMR</span>
                 </div>
                 {usdValue && (
-                  <div className="text-xs font-bold text-xmr-dim/60 uppercase tracking-[0.1em]">
-                    {usdValue} USD
-                  </div>
+                  <div className="text-xs font-bold text-xmr-dim/60 uppercase tracking-[0.1em] mb-3">{usdValue} USD</div>
                 )}
+
+                {/* Address */}
+                <div className="text-[10px] text-xmr-dim/30 tracking-wider">
+                  {currentAcc?.baseAddress?.substring(0, 12)}...{currentAcc?.baseAddress?.substring((currentAcc?.baseAddress?.length || 8) - 8)}
+                </div>
               </div>
 
-              {/* Card footer */}
-              <div className="flex justify-between items-end relative z-10">
-                <div className="text-[10px] text-xmr-dim/30 tracking-wider">
-                  {currentAcc?.baseAddress?.substring(0, 8)}...{currentAcc?.baseAddress?.substring((currentAcc?.baseAddress?.length || 8) - 6)}
+              {/* Right: portfolio summary + status */}
+              <div className="w-[280px] shrink-0 border-l border-xmr-border/15 p-5 flex flex-col justify-between">
+                {/* Portfolio total */}
+                <div>
+                  <div className="text-[9px] font-black uppercase tracking-widest text-xmr-dim/60 mb-1">Portfolio ({accounts.length} accts)</div>
+                  <div className="flex items-baseline gap-1.5">
+                    <span className="text-xl font-black text-xmr-green">{totalBalance.toFixed(4)}</span>
+                    <span className="text-[10px] text-xmr-dim font-bold">XMR</span>
+                  </div>
+                  {totalFiat && <div className="text-[10px] font-bold text-xmr-dim/40 uppercase tracking-wider">{totalFiat} USD</div>}
                 </div>
-                {/* Dot indicators */}
-                <div className="flex gap-1.5" onClick={(e) => e.stopPropagation()}>
-                  {accounts.map(acc => (
-                    <button
-                      key={acc.index}
-                      onClick={() => setSelectedAccountIndex(acc.index)}
-                      className={`w-[7px] h-[7px] rounded-full transition-all cursor-pointer ${acc.index === selectedAccountIndex
-                        ? 'bg-xmr-green shadow-[0_0_8px_var(--color-xmr-green)]'
-                        : 'bg-xmr-green/30 hover:bg-xmr-green/60'
-                      }`}
-                      title={acc.label || `Account ${acc.index}`}
-                    />
-                  ))}
+
+                {/* Status rows */}
+                <div className="space-y-1 mt-3 pt-3 border-t border-xmr-border/15">
+                  <div className="flex justify-between text-[10px] uppercase font-black">
+                    <span className="text-xmr-dim/40">Uplink:</span>
+                    <span className={`flex items-center gap-1 ${isSyncing ? 'text-xmr-accent' : 'text-xmr-green'}`}>
+                      {isSyncing && <Loader2 size={8} className="animate-spin" />}
+                      {status}
+                    </span>
+                  </div>
+                  <div className="flex justify-between text-[10px] uppercase font-black">
+                    <span className="text-xmr-dim/40">Height:</span>
+                    <span className="text-xmr-green">{currentHeight || '---'}</span>
+                  </div>
+                  <div className="flex justify-between text-[10px] uppercase font-black">
+                    <span className="text-xmr-dim/40">Unlocked:</span>
+                    <span className="text-xmr-green">{parseFloat(currentAcc?.unlockedBalance || '0').toFixed(4)}</span>
+                  </div>
+                  <div className="flex justify-between text-[10px] uppercase font-black">
+                    <span className="text-xmr-dim/40">Outputs:</span>
+                    <span className="text-xmr-green">{outputs?.length || 0}</span>
+                  </div>
+                </div>
+
+                {/* All accounts trigger */}
+                <div className="relative mt-3 pt-3 border-t border-xmr-border/15" ref={accountListRef}>
+                  <button
+                    onClick={() => setShowAccountList(!showAccountList)}
+                    className="w-full flex items-center justify-between text-[10px] font-black text-xmr-dim hover:text-xmr-green transition-colors cursor-pointer uppercase tracking-widest px-2.5 py-1.5 border border-xmr-border/20 rounded hover:border-xmr-green/40"
+                  >
+                    <span>All Accounts</span>
+                    <span className="text-xmr-green/60">{currentAccIdx + 1}/{accounts.length}</span>
+                  </button>
+                  {showAccountList && (
+                    <div className="absolute bottom-10 right-0 bg-xmr-base border border-xmr-border/50 rounded-md shadow-2xl z-50 w-[340px] max-h-[400px] flex flex-col animate-in fade-in slide-in-from-bottom-2 duration-150">
+                      <div className="px-4 py-3 border-b border-xmr-border/30 bg-xmr-green/5">
+                        <div className="flex justify-between items-center mb-1">
+                          <span className="text-[10px] font-black uppercase tracking-widest text-xmr-dim">All Accounts ({accounts.length})</span>
+                          <span className="text-[10px] font-black uppercase tracking-widest text-xmr-dim">Total</span>
+                        </div>
+                        <div className="flex justify-between items-baseline">
+                          <span className="text-[10px] text-xmr-dim/50 uppercase tracking-wider">Unlocked: {totalUnlocked.toFixed(4)}</span>
+                          <div className="text-right">
+                            <span className="text-sm font-black text-xmr-green">{totalBalance.toFixed(4)} XMR</span>
+                            {totalFiat && <div className="text-[10px] text-xmr-dim/60 font-bold">{totalFiat} USD</div>}
+                          </div>
+                        </div>
+                      </div>
+                      <div className="overflow-y-auto custom-scrollbar flex-1">
+                        {accounts.map(acc => (
+                          <button
+                            key={acc.index}
+                            onClick={() => { setSelectedAccountIndex(acc.index); setShowAccountList(false); }}
+                            className={`w-full px-4 py-2.5 flex items-center justify-between text-left transition-all cursor-pointer hover:bg-xmr-green/10 border-b border-xmr-border/10 ${acc.index === selectedAccountIndex ? 'bg-xmr-green/5 border-l-2 border-l-xmr-green' : ''}`}
+                          >
+                            <div className="flex items-center gap-3 min-w-0">
+                              <span className="text-[10px] text-xmr-dim font-bold shrink-0 w-6">{String(acc.index).padStart(2, '0')}</span>
+                              <span className="text-[11px] text-xmr-green font-black uppercase truncate">{acc.label || 'UNTITLED'}</span>
+                            </div>
+                            <div className="text-right shrink-0 ml-3">
+                              <div className="text-[11px] text-xmr-green font-bold">{parseFloat(acc.balance).toFixed(4)}</div>
+                              <div className="text-[9px] text-xmr-dim/50 font-bold">XMR</div>
+                            </div>
+                          </button>
+                        ))}
+                      </div>
+                      <button
+                        onClick={() => { handleOpenCreateModal(); setShowAccountList(false); }}
+                        className="px-4 py-2.5 text-center text-[10px] text-xmr-accent font-black uppercase tracking-widest hover:bg-xmr-accent/10 transition-all cursor-pointer border-t border-xmr-border/30 shrink-0"
+                      >
+                        + New Account
+                      </button>
+                    </div>
+                  )}
                 </div>
               </div>
             </div>
-          </div>
 
-          {/* Quick Actions Row */}
-          <div className="flex gap-3 justify-center">
-            {quickActions.map(action => (
-              <button
-                key={action.label}
-                onClick={action.onClick}
-                disabled={action.disabled}
-                className="flex flex-col items-center gap-1.5 group cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed"
-              >
-                <div className="w-[52px] h-[52px] rounded-full border border-xmr-green/30 flex items-center justify-center bg-xmr-base text-xmr-green group-hover:border-xmr-green/80 group-hover:bg-xmr-green/10 group-hover:scale-105 transition-all disabled:group-hover:scale-100">
-                  <action.icon size={18} className={action.spin ? 'animate-spin' : ''} />
-                </div>
-                <span className="text-[9px] font-black uppercase tracking-[0.15em] text-xmr-dim group-hover:text-xmr-green transition-colors">
-                  {action.label}
-                </span>
-              </button>
-            ))}
           </div>
         </div>
 
-        {/* RIGHT: Identity Status (enhanced with Unlocked + Outputs) */}
-        <Card className="flex flex-col justify-between p-4! h-fit">
-          <div className="flex justify-between items-start font-black">
-            <span className="text-xs text-xmr-dim uppercase tracking-widest font-black">Identity_Status</span>
-            <button onClick={revealSeed} className="text-xmr-green hover:text-xmr-accent transition-all cursor-pointer">
-              <Key size={16} />
-            </button>
-          </div>
-          <div className="p-3 bg-xmr-base border border-xmr-border/30 rounded-sm font-black overflow-hidden mt-3">
-            <div className="flex justify-between items-center mb-1 font-black"><span className="text-xs opacity-50 text-xmr-green font-black uppercase">SESSION_ADDRESS</span></div>
-            <AddressDisplay address={address} className="text-[11px] " />
-          </div>
-          <div className="space-y-1.5 border-t border-xmr-border/20 pt-4 mt-3 font-black">
-            <div className="flex justify-between text-[11px] uppercase font-black">
-              <span className="opacity-40 text-xmr-green">Uplink:</span>
-              <span className={`font-black flex items-center gap-1.5 ${isSyncing ? 'text-xmr-accent animate-pulse' : 'text-xmr-green'}`}>
-                {isSyncing && <Loader2 size={10} className="animate-spin" />}
-                {status}
+        {/* Quick Actions Row */}
+        <div className="flex gap-3 justify-center">
+          {quickActions.map(action => (
+            <button
+              key={action.label}
+              onClick={action.onClick}
+              disabled={action.disabled}
+              className="flex flex-col items-center gap-1.5 group cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed"
+            >
+              <div className="w-[48px] h-[48px] rounded-full border border-xmr-green/30 flex items-center justify-center bg-xmr-base text-xmr-green group-hover:border-xmr-green/80 group-hover:bg-xmr-green/10 group-hover:scale-105 transition-all">
+                <action.icon size={16} className={action.spin ? 'animate-spin' : ''} />
+              </div>
+              <span className="text-[9px] font-black uppercase tracking-[0.15em] text-xmr-dim group-hover:text-xmr-green transition-colors">
+                {action.label}
               </span>
-            </div>
-            <div className="flex justify-between text-[11px] uppercase font-black"><span className="opacity-40 text-xmr-green">Height:</span><span className="text-xmr-green">{currentHeight || '---'}</span></div>
-            <div className="flex justify-between text-[11px] uppercase font-black"><span className="opacity-40 text-xmr-green">Unlocked:</span><span className="text-xmr-green">{parseFloat(currentAcc?.unlockedBalance || '0').toFixed(4)}</span></div>
-            <div className="flex justify-between text-[11px] uppercase font-black"><span className="opacity-40 text-xmr-green">Outputs:</span><span className="text-xmr-green">{outputs?.length || 0}</span></div>
-          </div>
-        </Card>
+            </button>
+          ))}
+        </div>
       </div>
 
       {/* 3. TABS NAVIGATION */}

--- a/src/renderer/components/VaultView.tsx
+++ b/src/renderer/components/VaultView.tsx
@@ -136,7 +136,10 @@ export function VaultView({ setView, vault, handleBurn, appConfig }: VaultViewPr
   };
 
   const isSyncing = status === 'SYNCING' || status === 'READY';
-  const isFullySynced = status === 'SYNCED';
+  const blocksLeft = totalHeight > 0 && currentHeight > 0 ? totalHeight - currentHeight : 0;
+  // Only block actions for large syncs (>1000 blocks ≈ 1.4 days behind)
+  // Small gaps (<1000 blocks) catch up in seconds — no need to lock the UI
+  const isHeavySync = isSyncing && blocksLeft > 1000;
 
   const currentAccIdx = accounts.findIndex(a => a.index === selectedAccountIndex);
   const prevAccount = () => {
@@ -156,10 +159,10 @@ export function VaultView({ setView, vault, handleBurn, appConfig }: VaultViewPr
   const { fiatText: totalFiat } = useFiatValue('XMR', totalBalance.toFixed(12), true);
 
   const quickActions = [
-    { label: 'Dispatch', icon: Send, onClick: () => setModals(prev => ({ ...prev, send: true })), disabled: isSyncing },
-    { label: 'Receive', icon: Download, onClick: () => setModals(prev => ({ ...prev, receive: true })), disabled: isSyncing },
-    { label: 'Churn', icon: Wind, onClick: () => setModals(prev => ({ ...prev, churn: true })), disabled: isSyncing || isSending || hasNoBalance },
-    { label: 'Splinter', icon: Scissors, onClick: () => setModals(prev => ({ ...prev, splinter: true })), disabled: isSyncing || isSending || hasNoBalance },
+    { label: 'Dispatch', icon: Send, onClick: () => setModals(prev => ({ ...prev, send: true })), disabled: isHeavySync },
+    { label: 'Receive', icon: Download, onClick: () => setModals(prev => ({ ...prev, receive: true })), disabled: isHeavySync },
+    { label: 'Churn', icon: Wind, onClick: () => setModals(prev => ({ ...prev, churn: true })), disabled: isHeavySync || isSending || hasNoBalance },
+    { label: 'Splinter', icon: Scissors, onClick: () => setModals(prev => ({ ...prev, splinter: true })), disabled: isHeavySync || isSending || hasNoBalance },
     { label: 'Sync', icon: RefreshCw, onClick: refresh, disabled: false, spin: isSyncing || isSending },
   ];
 
@@ -174,13 +177,13 @@ export function VaultView({ setView, vault, handleBurn, appConfig }: VaultViewPr
         </div>
       </div>
 
-      {/* SYNC STATUS BANNER */}
-      {isSyncing && (
+      {/* SYNC STATUS BANNER — only for heavy syncs (>1000 blocks behind) */}
+      {isHeavySync && (
         <div className="flex items-center gap-3 px-4 py-3 bg-xmr-accent/10 border border-xmr-accent/30 rounded-sm animate-pulse">
           <Loader2 size={14} className="text-xmr-accent animate-spin shrink-0" />
           <span className="text-xs font-black text-xmr-accent uppercase tracking-widest leading-relaxed">
             Synchronizing_Ledger... Height: {currentHeight || '---'}
-            {totalHeight > 0 && currentHeight > 0 ? ` ( ${Math.max(0, totalHeight - currentHeight)} BLOCKS LEFT : ${syncPercent?.toFixed(2)}% )` : ''}
+            {blocksLeft > 0 ? ` ( ${blocksLeft} BLOCKS LEFT : ${syncPercent?.toFixed(2)}% )` : ''}
             — Send/Receive disabled until sync completes
           </span>
         </div>

--- a/src/renderer/components/VaultView.tsx
+++ b/src/renderer/components/VaultView.tsx
@@ -169,14 +169,6 @@ export function VaultView({ setView, vault, handleBurn, appConfig }: VaultViewPr
   return (
     <div className="max-w-6xl mx-auto space-y-6 py-2 pt-0 animate-in fade-in zoom-in-95 duration-300 font-black relative">
 
-      {/* 1. HEADER */}
-      <div className="flex justify-between items-end border-b border-xmr-border/30 pb-4 relative z-10 font-black">
-        <div>
-          <button onClick={() => setView('home')} className="text-xs text-xmr-dim hover:text-xmr-green mb-1 flex items-center gap-1 cursor-pointer font-black transition-all uppercase tracking-widest">[ DASHBOARD ]</button>
-          <h2 className="text-3xl font-black italic uppercase tracking-tighter text-xmr-green font-mono leading-none">Vault_Storage</h2>
-        </div>
-      </div>
-
       {/* SYNC STATUS BANNER — only for heavy syncs (>1000 blocks behind) */}
       {isHeavySync && (
         <div className="flex items-center gap-3 px-4 py-3 bg-xmr-accent/10 border border-xmr-accent/30 rounded-sm animate-pulse">
@@ -294,16 +286,33 @@ export function VaultView({ setView, vault, handleBurn, appConfig }: VaultViewPr
 
                 {/* Balance */}
                 <div className="flex items-baseline gap-2.5 mb-1">
-                  <span className="text-4xl font-black text-xmr-green leading-none">{currentAccBalance}</span>
-                  <span className="text-base text-xmr-dim font-bold">XMR</span>
+                  <span className="text-4xl font-black text-xmr-green leading-none" style={{ fontFamily: 'var(--font-display)' }}>{currentAccBalance}</span>
+                  <span className="text-sm text-xmr-dim font-medium" style={{ fontFamily: 'var(--font-display)' }}>XMR</span>
                 </div>
                 {usdValue && (
-                  <div className="text-xs font-bold text-xmr-dim/60 uppercase tracking-[0.1em] mb-3">{usdValue} USD</div>
+                  <div className="text-xs font-bold text-xmr-dim/60 uppercase tracking-[0.1em] mb-2">{usdValue} USD</div>
                 )}
 
                 {/* Address */}
-                <div className="text-[10px] text-xmr-dim/30 tracking-wider">
+                <div className="text-[10px] text-xmr-dim/30 tracking-wider mb-3">
                   {currentAcc?.baseAddress?.substring(0, 12)}...{currentAcc?.baseAddress?.substring((currentAcc?.baseAddress?.length || 8) - 8)}
+                </div>
+
+                {/* Quick Actions — inline in card */}
+                <div className="flex gap-2 flex-wrap">
+                  {quickActions.map(action => (
+                    <button
+                      key={action.label}
+                      onClick={action.onClick}
+                      disabled={action.disabled}
+                      className="flex items-center gap-2 px-4 py-2 rounded-xl border border-xmr-green/20 bg-xmr-base/40 text-xmr-green hover:border-xmr-green/50 hover:bg-xmr-green/10 transition-all cursor-pointer disabled:opacity-30 disabled:cursor-not-allowed group"
+                    >
+                      <action.icon size={14} className={action.spin ? 'animate-spin' : ''} />
+                      <span className="text-[9px] font-bold uppercase tracking-[0.12em] group-hover:text-xmr-green transition-colors">
+                        {action.label}
+                      </span>
+                    </button>
+                  ))}
                 </div>
               </div>
 
@@ -313,7 +322,7 @@ export function VaultView({ setView, vault, handleBurn, appConfig }: VaultViewPr
                 <div>
                   <div className="text-[9px] font-black uppercase tracking-widest text-xmr-dim/60 mb-1">Portfolio ({accounts.length} accts)</div>
                   <div className="flex items-baseline gap-1.5">
-                    <span className="text-xl font-black text-xmr-green">{totalBalance.toFixed(4)}</span>
+                    <span className="text-xl font-black text-xmr-green" style={{ fontFamily: 'var(--font-display)' }}>{totalBalance.toFixed(4)}</span>
                     <span className="text-[10px] text-xmr-dim font-bold">XMR</span>
                   </div>
                   {totalFiat && <div className="text-[10px] font-bold text-xmr-dim/40 uppercase tracking-wider">{totalFiat} USD</div>}
@@ -399,41 +408,25 @@ export function VaultView({ setView, vault, handleBurn, appConfig }: VaultViewPr
           </div>
         </div>
 
-        {/* Quick Actions Row */}
-        <div className="flex gap-3 justify-center">
-          {quickActions.map(action => (
+      </div>
+
+      {/* 3. TABS + CONTENT */}
+      <div className="min-h-[400px] border border-xmr-border/20 rounded-lg overflow-hidden bg-xmr-surface/30">
+        {/* Tab bar — inside the content border */}
+        <div className="flex gap-1 items-center px-3 py-2 border-b border-xmr-border/15 bg-xmr-surface/50">
+          {['ledger', 'coins', 'addresses', 'contacts'].map((t) => (
             <button
-              key={action.label}
-              onClick={action.onClick}
-              disabled={action.disabled}
-              className="flex flex-col items-center gap-1.5 group cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed"
+              key={t}
+              onClick={() => setTab(t as any)}
+              className={`px-4 py-2 text-[11px] font-black uppercase tracking-widest transition-all rounded-lg ${tab === t ? 'text-xmr-green border border-xmr-green/30 bg-xmr-green/5' : 'text-xmr-dim hover:text-xmr-green border border-transparent'}`}
             >
-              <div className="w-[48px] h-[48px] rounded-full border border-xmr-green/30 flex items-center justify-center bg-xmr-base text-xmr-green group-hover:border-xmr-green/80 group-hover:bg-xmr-green/10 group-hover:scale-105 transition-all">
-                <action.icon size={16} className={action.spin ? 'animate-spin' : ''} />
-              </div>
-              <span className="text-[9px] font-black uppercase tracking-[0.15em] text-xmr-dim group-hover:text-xmr-green transition-colors">
-                {action.label}
-              </span>
+              {t}
             </button>
           ))}
         </div>
-      </div>
 
-      {/* 3. TABS NAVIGATION */}
-      <div className="flex gap-4 border-b border-xmr-border/20">
-        {['ledger', 'coins', 'addresses', 'contacts'].map((t) => (
-          <button
-            key={t}
-            onClick={() => setTab(t as any)}
-            className={`px-6 py-3 text-xs font-black uppercase tracking-widest transition-all border-b-2 ${tab === t ? 'border-xmr-green text-xmr-green bg-xmr-green/5' : 'border-transparent text-xmr-dim hover:text-xmr-green'}`}
-          >
-            {t.replace('_', ' ')}
-          </button>
-        ))}
-      </div>
-
-      {/* 4. TAB CONTENT */}
-      <div className="min-h-[400px]">
+        {/* Tab content */}
+        <div>
         {tab === 'ledger' && <TransactionLedger txs={txs} subaddresses={subaddresses} />}
         {tab === 'coins' && <CoinControl outputs={outputs} onSendFromCoin={(_keyImage, _amount) => { setModals(prev => ({ ...prev, send: true })); }} />}
         {tab === 'addresses' && <AddressList
@@ -454,6 +447,7 @@ export function VaultView({ setView, vault, handleBurn, appConfig }: VaultViewPr
           onDispatch={(addr) => { setDispatchAddr(addr); setModals(prev => ({ ...prev, send: true })); }}
           handleCopy={handleCopy}
         />}
+        </div>
       </div>
 
       {/* 5. MODALS */}

--- a/src/renderer/components/auth/AuthForm.tsx
+++ b/src/renderer/components/auth/AuthForm.tsx
@@ -133,11 +133,17 @@ export function AuthForm({
 
       <div className="flex flex-col gap-3">
         <button disabled={isProcessing || !password || (step !== 'AUTH' && !confirmPassword)} className="w-full py-4 bg-xmr-green text-xmr-base font-black uppercase tracking-[0.3em] hover:bg-white hover:text-black transition-all flex items-center justify-center gap-3 group disabled:opacity-50 cursor-pointer">
-          {isProcessing ? <><RefreshCw size={18} className="animate-spin" /> Authorizing...</> : <><Key size={18} className="group-hover:scale-110 transition-transform" /> {step === 'RESTORE' ? 'Initiate_Recovery' : step === 'NEW_PASSWORD' ? 'Establish_Vault' : 'Unlock_Identity'}</>}
+          {isProcessing ? <><RefreshCw size={18} className="animate-spin" /> Authorizing...</> : <><Key size={18} className="group-hover:scale-110 transition-transform" /> {step === 'RESTORE' ? 'Restore Wallet' : step === 'NEW_PASSWORD' ? 'Create Wallet' : 'Unlock'}</>}
         </button>
-        
-        {!isProcessing && step !== 'AUTH' && (
-           <button type="button" onClick={() => setStep('MODE')} className="w-full text-[11px] text-xmr-dim hover:text-xmr-green uppercase flex items-center justify-center gap-2 transition-colors cursor-pointer"><ArrowLeft size={12}/> Back_To_Strategy</button>
+
+        {!isProcessing && step === 'NEW_PASSWORD' && isInitialSetup && (
+           <button type="button" onClick={() => setStep('RESTORE')} className="w-full text-[11px] text-xmr-dim hover:text-xmr-green uppercase flex items-center justify-center gap-2 transition-colors cursor-pointer"><Download size={12}/> Restore from Seed</button>
+        )}
+        {!isProcessing && step === 'RESTORE' && (
+           <button type="button" onClick={() => setStep('NEW_PASSWORD')} className="w-full text-[11px] text-xmr-dim hover:text-xmr-green uppercase flex items-center justify-center gap-2 transition-colors cursor-pointer"><ArrowLeft size={12}/> Back</button>
+        )}
+        {!isProcessing && step !== 'AUTH' && step !== 'NEW_PASSWORD' && step !== 'RESTORE' && (
+           <button type="button" onClick={() => setStep('MODE')} className="w-full text-[11px] text-xmr-dim hover:text-xmr-green uppercase flex items-center justify-center gap-2 transition-colors cursor-pointer"><ArrowLeft size={12}/> Back</button>
         )}
       </div>
     </form>

--- a/src/renderer/components/vault/ChurnModal.tsx
+++ b/src/renderer/components/vault/ChurnModal.tsx
@@ -25,7 +25,7 @@ export function ChurnModal({ onClose, onChurn, unlockedBalance }: ChurnModalProp
   };
 
   return (
-    <div className="fixed inset-0 z-[100] flex items-center justify-center p-6 bg-xmr-base/90 backdrop-blur-md animate-in fade-in duration-300">
+    <div className="fixed top-0 bottom-0 right-0 left-[14rem] z-[100] flex items-center justify-center p-6 bg-xmr-base/90 backdrop-blur-md animate-in fade-in duration-300">
       <div className="w-full max-w-lg bg-xmr-base/80 text-xmr-dim p-8 border-4 border-xmr-green relative rounded-lg">
         <button onClick={onClose} disabled={isProcessing} className="absolute top-4 right-4 cursor-pointer disabled:opacity-50">
           <X size={24} />

--- a/src/renderer/components/vault/DispatchModal.tsx
+++ b/src/renderer/components/vault/DispatchModal.tsx
@@ -9,11 +9,12 @@ interface DispatchModalProps {
   onClose: () => void;
   initialAddress?: string;
   sourceSubaddressIndex?: number;
+  inline?: boolean;
 }
 
 type Tab = 'direct' | 'ghost';
 
-export function DispatchModal({ onClose, initialAddress = '', sourceSubaddressIndex }: DispatchModalProps) {
+export function DispatchModal({ onClose, initialAddress = '', sourceSubaddressIndex, inline }: DispatchModalProps) {
   const { activeId, outputs } = useVault();
   const [tab, setTab] = useState<Tab>('direct');
 
@@ -47,9 +48,8 @@ export function DispatchModal({ onClose, initialAddress = '', sourceSubaddressIn
     }
   };
 
-  return (
-    <div className="fixed inset-0 z-[100] flex items-center justify-center p-4 bg-xmr-base/90 backdrop-blur-md animate-in zoom-in-95 duration-300 font-black">
-      <div className="w-full max-w-xl bg-xmr-surface border border-xmr-border relative flex flex-col max-h-[85vh] overflow-hidden rounded-lg">
+  const content = (
+      <div className={`w-full ${inline ? '' : 'max-w-xl'} bg-xmr-surface ${inline ? '' : 'border border-xmr-border'} relative flex flex-col ${inline ? 'h-full' : 'max-h-[85vh]'} overflow-hidden ${inline ? '' : 'rounded-lg'}`}>
         {/* ══ PASSWORD GATE ══ */}
         {showPasswordGate && (
           <DispatchPasswordGate
@@ -113,6 +113,13 @@ export function DispatchModal({ onClose, initialAddress = '', sourceSubaddressIn
           {tab === 'ghost' && <GhostSendTab onRequirePassword={requirePassword} onClose={onClose} />}
         </div>
       </div>
+  );
+
+  if (inline) return content;
+
+  return (
+    <div className="fixed inset-0 z-[100] flex items-center justify-center p-4 bg-xmr-base/90 backdrop-blur-md animate-in zoom-in-95 duration-300 font-black">
+      {content}
     </div>
   );
 }

--- a/src/renderer/components/vault/DispatchModal.tsx
+++ b/src/renderer/components/vault/DispatchModal.tsx
@@ -49,7 +49,7 @@ export function DispatchModal({ onClose, initialAddress = '', sourceSubaddressIn
   };
 
   const content = (
-      <div className={`w-full ${inline ? '' : 'max-w-xl'} bg-xmr-surface ${inline ? '' : 'border border-xmr-border'} relative flex flex-col ${inline ? 'h-full' : 'max-h-[85vh]'} overflow-hidden ${inline ? '' : 'rounded-lg'}`}>
+      <div className={`w-full ${inline ? '' : 'max-w-xl bg-xmr-surface border border-xmr-border rounded-lg'} relative flex flex-col ${inline ? 'h-full' : 'max-h-[85vh]'} overflow-hidden`}>
         {/* ══ PASSWORD GATE ══ */}
         {showPasswordGate && (
           <DispatchPasswordGate
@@ -65,37 +65,30 @@ export function DispatchModal({ onClose, initialAddress = '', sourceSubaddressIn
           />
         )}
 
-        {/* Header */}
-        <div className="flex items-center justify-between px-6 py-4 border-b border-xmr-border/40">
-          <div>
-            <h3 className="text-lg font-black italic uppercase text-xmr-accent tracking-tight">Dispatch_Sequence</h3>
-            <p className="text-[11px] text-xmr-dim uppercase tracking-widest mt-0.5">
-              {sourceSubaddressIndex !== undefined ? `Source: Subaddress #${sourceSubaddressIndex}` : 'Outbound transfer'}
-            </p>
+        {/* Header — matches tab bar style when inline */}
+        <div className={`flex items-center justify-between ${inline ? 'px-3 py-2 bg-xmr-surface/50' : 'px-6 py-4'} border-b border-xmr-border/${inline ? '15' : '40'}`}>
+          <div className="flex gap-1 items-center">
+            {/* Sub-tabs: Direct / Ghost */}
+            {[
+              { id: 'direct' as const, label: 'Direct XMR', icon: <Send size={12} /> },
+              { id: 'ghost' as const, label: 'Ghost Send', icon: <Ghost size={12} /> },
+            ].map((t) => (
+              <button
+                key={t.id}
+                onClick={() => setTab(t.id)}
+                className={`px-4 py-2 text-[11px] font-black uppercase tracking-widest transition-all rounded-lg flex items-center gap-1.5 cursor-pointer ${
+                  tab === t.id
+                    ? 'text-xmr-accent border border-xmr-accent/30 bg-xmr-accent/5'
+                    : 'text-xmr-dim hover:text-xmr-accent border border-transparent'
+                }`}
+              >
+                {t.icon} {t.label}
+              </button>
+            ))}
           </div>
           <button onClick={onClose} className="text-xmr-dim hover:text-xmr-accent transition-colors cursor-pointer p-1">
             <X size={20} />
           </button>
-        </div>
-
-        {/* Tabs */}
-        <div className="flex border-b border-xmr-border/30">
-          {[
-            { id: 'direct' as const, label: 'Direct XMR', icon: <Send size={12} /> },
-            { id: 'ghost' as const, label: 'Ghost Send', icon: <Ghost size={12} /> },
-          ].map((t) => (
-            <button
-              key={t.id}
-              onClick={() => setTab(t.id)}
-              className={`flex-1 py-2.5 text-[11px] font-black uppercase tracking-widest transition-all flex items-center justify-center gap-1.5 cursor-pointer ${
-                tab === t.id
-                  ? 'text-xmr-accent border-b-2 border-xmr-accent bg-xmr-accent/5'
-                  : 'text-xmr-dim hover:text-xmr-accent/70'
-              }`}
-            >
-              {t.icon} {t.label}
-            </button>
-          ))}
         </div>
 
         {/* Body */}
@@ -118,7 +111,7 @@ export function DispatchModal({ onClose, initialAddress = '', sourceSubaddressIn
   if (inline) return content;
 
   return (
-    <div className="fixed inset-0 z-[100] flex items-center justify-center p-4 bg-xmr-base/90 backdrop-blur-md animate-in zoom-in-95 duration-300 font-black">
+    <div className="fixed top-0 bottom-0 right-0 left-[14rem] z-[100] flex items-center justify-center p-4 bg-xmr-base/90 backdrop-blur-md animate-in zoom-in-95 duration-300 font-black">
       {content}
     </div>
   );

--- a/src/renderer/components/vault/ReceiveModal.tsx
+++ b/src/renderer/components/vault/ReceiveModal.tsx
@@ -14,9 +14,10 @@ interface ExistingAddress {
 interface ReceiveModalProps {
   onClose: () => void;
   existingAddress?: ExistingAddress;
+  inline?: boolean;
 }
 
-export function ReceiveModal({ onClose, existingAddress }: ReceiveModalProps) {
+export function ReceiveModal({ onClose, existingAddress, inline }: ReceiveModalProps) {
   const { createSubaddress, setSubaddressLabel, subaddresses } = useVault();
   const [tab, setTab] = useState<'direct' | 'cross'>('direct');
 
@@ -100,9 +101,8 @@ export function ReceiveModal({ onClose, existingAddress }: ReceiveModalProps) {
     </div>
   );
 
-  return (
-    <div className="fixed inset-0 z-[100] flex items-center justify-center p-4 bg-xmr-base/90 backdrop-blur-md animate-in zoom-in-95 duration-300 font-black">
-      <div className="w-full max-w-xl bg-xmr-surface border border-xmr-border relative flex flex-col max-h-[85vh] overflow-hidden rounded-lg">
+  const content = (
+      <div className={`w-full ${inline ? '' : 'max-w-xl'} bg-xmr-surface ${inline ? '' : 'border border-xmr-border'} relative flex flex-col ${inline ? 'h-full' : 'max-h-[85vh]'} overflow-hidden ${inline ? '' : 'rounded-lg'}`}>
 
         {/* Header */}
         <div className="flex items-center justify-between px-6 py-4 border-b border-xmr-border/40">
@@ -203,6 +203,13 @@ export function ReceiveModal({ onClose, existingAddress }: ReceiveModalProps) {
           )}
         </div>
       </div>
+  );
+
+  if (inline) return content;
+
+  return (
+    <div className="fixed inset-0 z-[100] flex items-center justify-center p-4 bg-xmr-base/90 backdrop-blur-md animate-in zoom-in-95 duration-300 font-black">
+      {content}
     </div>
   );
 }

--- a/src/renderer/components/vault/ReceiveModal.tsx
+++ b/src/renderer/components/vault/ReceiveModal.tsx
@@ -102,38 +102,28 @@ export function ReceiveModal({ onClose, existingAddress, inline }: ReceiveModalP
   );
 
   const content = (
-      <div className={`w-full ${inline ? '' : 'max-w-xl'} bg-xmr-surface ${inline ? '' : 'border border-xmr-border'} relative flex flex-col ${inline ? 'h-full' : 'max-h-[85vh]'} overflow-hidden ${inline ? '' : 'rounded-lg'}`}>
+      <div className={`w-full ${inline ? '' : 'max-w-xl bg-xmr-surface border border-xmr-border rounded-lg'} relative flex flex-col ${inline ? 'h-full' : 'max-h-[85vh]'} overflow-hidden`}>
 
-        {/* Header */}
-        <div className="flex items-center justify-between px-6 py-4 border-b border-xmr-border/40">
-          <div>
-            <h3 className="text-lg font-black italic uppercase text-xmr-green tracking-tight">
-              {existingAddress ? 'Address_Detail' : 'Incoming_Uplink'}
-            </h3>
-            <p className="text-[11px] text-xmr-dim uppercase tracking-widest mt-0.5">
-              {existingAddress ? `Subaddress #${existingAddress.index}` : 'One-time subaddress'} • {generatedAddress ? 'Ready' : 'Generating...'}
-            </p>
+        {/* Header — matches tab bar style when inline */}
+        <div className={`flex items-center justify-between ${inline ? 'px-3 py-2 bg-xmr-surface/50' : 'px-6 py-4'} border-b border-xmr-border/${inline ? '15' : '40'}`}>
+          <div className="flex gap-1 items-center">
+            {([
+              { id: 'direct' as const, label: 'Direct XMR', icon: <ArrowDownToLine size={12} /> },
+              { id: 'cross' as const, label: 'Payment Link', icon: <Shuffle size={12} /> },
+            ]).map(t => (
+              <button
+                key={t.id}
+                onClick={() => setTab(t.id)}
+                className={`px-4 py-2 text-[11px] font-black uppercase tracking-widest transition-all rounded-lg flex items-center gap-1.5 cursor-pointer ${tab === t.id
+                    ? 'text-xmr-green border border-xmr-green/30 bg-xmr-green/5'
+                    : 'text-xmr-dim hover:text-xmr-green border border-transparent'
+                  }`}
+              >
+                {t.icon} {t.label}
+              </button>
+            ))}
           </div>
           <button onClick={onClose} className="text-xmr-dim hover:text-xmr-green transition-colors cursor-pointer p-1"><X size={20} /></button>
-        </div>
-
-        {/* Tabs */}
-        <div className="flex border-b border-xmr-border/30">
-          {([
-            { id: 'direct' as const, label: 'Direct XMR', icon: <ArrowDownToLine size={12} /> },
-            { id: 'cross' as const, label: 'Payment Link', icon: <Shuffle size={12} /> },
-          ]).map(t => (
-            <button
-              key={t.id}
-              onClick={() => setTab(t.id)}
-              className={`flex-1 py-2.5 text-[11px] font-black uppercase tracking-widest transition-all flex items-center justify-center gap-1.5 cursor-pointer ${tab === t.id
-                  ? 'text-xmr-green border-b-2 border-xmr-green bg-xmr-green/5'
-                  : 'text-xmr-dim hover:text-xmr-green/70'
-                }`}
-            >
-              {t.icon} {t.label}
-            </button>
-          ))}
         </div>
 
         {/* Body */}
@@ -208,7 +198,7 @@ export function ReceiveModal({ onClose, existingAddress, inline }: ReceiveModalP
   if (inline) return content;
 
   return (
-    <div className="fixed inset-0 z-[100] flex items-center justify-center p-4 bg-xmr-base/90 backdrop-blur-md animate-in zoom-in-95 duration-300 font-black">
+    <div className="fixed top-0 bottom-0 right-0 left-[14rem] z-[100] flex items-center justify-center p-4 bg-xmr-base/90 backdrop-blur-md animate-in zoom-in-95 duration-300 font-black">
       {content}
     </div>
   );

--- a/src/renderer/components/vault/SplinterModal.tsx
+++ b/src/renderer/components/vault/SplinterModal.tsx
@@ -31,12 +31,13 @@ export function SplinterModal({ onClose, onSplinter, unlockedBalance }: Splinter
 
   return (
     <div className="fixed inset-0 z-[100] flex items-center justify-center p-6 bg-xmr-base/90 backdrop-blur-md animate-in fade-in duration-300">
-      <div className="w-full max-w-lg bg-xmr-base/80 text-xmr-dim p-8 border-4 border-xmr-accent relative rounded-lg">
-        <button onClick={onClose} disabled={isProcessing} className="absolute top-4 right-4 cursor-pointer disabled:opacity-50">
+      <div className="w-full max-w-lg max-h-[90vh] bg-xmr-base/80 text-xmr-dim border-4 border-xmr-accent relative rounded-lg flex flex-col">
+        <button onClick={onClose} disabled={isProcessing} className="absolute top-4 right-4 cursor-pointer disabled:opacity-50 z-10">
           <X size={24} />
         </button>
-        
-        <div className="space-y-6 font-normal">
+
+        {/* Scrollable content */}
+        <div className="overflow-y-auto custom-scrollbar p-8 pb-4 space-y-6 font-normal flex-1 min-h-0">
           <div className="flex items-center gap-3 text-xmr-accent font-black">
             <Scissors size={32} />
             <h3 className="text-2xl font-black uppercase tracking-tighter">Tactical_Splinter</h3>
@@ -44,13 +45,13 @@ export function SplinterModal({ onClose, onSplinter, unlockedBalance }: Splinter
 
           <div className="text-sm font-mono leading-relaxed space-y-4">
             <p>
-              Splintering protects your privacy by algorithmically shattering your entire unlocked XMR balance 
+              Splintering protects your privacy by algorithmically shattering your entire unlocked XMR balance
               into multiple smaller UTXOs (Unspent Transaction Outputs) across newly generated stealth addresses.
             </p>
             <p className="opacity-80">
-              Why use it? If you have a massive XMR balance sitting in a single UTXO, sending even a tiny amount 
-              forces you to expose and spend that massive UTXO as an input, creating "toxic change" that could 
-              temporarily reveal your net-worth or expose your spending patterns to advanced timing analysis. 
+              Why use it? If you have a massive XMR balance sitting in a single UTXO, sending even a tiny amount
+              forces you to expose and spend that massive UTXO as an input, creating "toxic change" that could
+              temporarily reveal your net-worth or expose your spending patterns to advanced timing analysis.
               Splintering breaks your balance down, ensuring you always spend appropriately sized chunks instead of huge payloads.
             </p>
           </div>
@@ -73,10 +74,10 @@ export function SplinterModal({ onClose, onSplinter, unlockedBalance }: Splinter
 
           <div className="bg-black/5 p-4 border border-xmr-border">
             <label className="block text-xs uppercase tracking-widest text-xmr-dim/60 mb-2">Number of Fragments (2-10)</label>
-            <input 
-              type="number" 
-              min="2" max="10" 
-              value={fragments} 
+            <input
+              type="number"
+              min="2" max="10"
+              value={fragments}
               onChange={(e) => setFragments(parseInt(e.target.value) || 2)}
               className="w-full bg-xmr-surface/80 border border-xmr-border/20 p-3 text-lg outline-none focus:border-xmr-accent transition-colors"
               disabled={isProcessing}
@@ -84,9 +85,12 @@ export function SplinterModal({ onClose, onSplinter, unlockedBalance }: Splinter
           </div>
 
           {error && <div className="text-red-500 text-xs font-mono">{error}</div>}
+        </div>
 
-          <button 
-            onClick={handleSubmit} 
+        {/* Sticky footer button */}
+        <div className="p-6 pt-4 border-t border-xmr-accent/20 shrink-0">
+          <button
+            onClick={handleSubmit}
             disabled={isProcessing || unlockedBalance <= 0}
             className="w-full py-4 bg-xmr-accent text-white font-black uppercase tracking-[0.2em] font-mono cursor-pointer hover:opacity-90 transition-opacity disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
           >

--- a/src/renderer/components/vault/SplinterModal.tsx
+++ b/src/renderer/components/vault/SplinterModal.tsx
@@ -30,7 +30,7 @@ export function SplinterModal({ onClose, onSplinter, unlockedBalance }: Splinter
   };
 
   return (
-    <div className="fixed inset-0 z-[100] flex items-center justify-center p-6 bg-xmr-base/90 backdrop-blur-md animate-in fade-in duration-300">
+    <div className="fixed top-0 bottom-0 right-0 left-[14rem] z-[100] flex items-center justify-center p-6 bg-xmr-base/90 backdrop-blur-md animate-in fade-in duration-300">
       <div className="w-full max-w-lg max-h-[90vh] bg-xmr-base/80 text-xmr-dim border-4 border-xmr-accent relative rounded-lg flex flex-col">
         <button onClick={onClose} disabled={isProcessing} className="absolute top-4 right-4 cursor-pointer disabled:opacity-50 z-10">
           <X size={24} />

--- a/src/renderer/components/vault/TransactionLedger.tsx
+++ b/src/renderer/components/vault/TransactionLedger.tsx
@@ -41,6 +41,34 @@ function getRelativeTime(timestamp: number) {
   return `${Math.floor(diffInDays / 365)}y ago`;
 }
 
+function getDateLabel(timestamp: number): string {
+  const date = new Date(timestamp);
+  const today = new Date();
+  const yesterday = new Date(today);
+  yesterday.setDate(yesterday.getDate() - 1);
+
+  if (date.toDateString() === today.toDateString()) {
+    return `Today — ${date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })}`;
+  }
+  if (date.toDateString() === yesterday.toDateString()) {
+    return `Yesterday — ${date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })}`;
+  }
+  return date.toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric' });
+}
+
+function groupByDate(txs: Transaction[]): { label: string; txs: Transaction[] }[] {
+  const groups: Map<string, Transaction[]> = new Map();
+  for (const tx of txs) {
+    const key = new Date(tx.timestamp).toDateString();
+    if (!groups.has(key)) groups.set(key, []);
+    groups.get(key)!.push(tx);
+  }
+  return Array.from(groups.entries()).map(([key, txs]) => ({
+    label: getDateLabel(txs[0].timestamp),
+    txs,
+  }));
+}
+
 export function TransactionLedger({ txs, subaddresses = [] }: TransactionLedgerProps) {
   const { getTxKey, getTxProof, checkTxKey, checkTxProof, addLog } = useVault();
   const [expandedTxId, setExpandedTxId] = useState<string | null>(null);
@@ -291,8 +319,13 @@ export function TransactionLedger({ txs, subaddresses = [] }: TransactionLedgerP
               <span>No_Ledger_Activity_Found</span>
             </div>
           ) : (
-            <div className="divide-y divide-xmr-border/5">
-                {txs.map((tx) => {
+            <div>
+              {groupByDate(txs).map((group) => (
+                <div key={group.label}>
+                  <div className="sticky top-0 z-[2] px-4 py-2 text-[9px] font-bold uppercase tracking-[0.2em] text-xmr-dim/60 bg-xmr-base border-b border-xmr-border/10">
+                    {group.label}
+                  </div>
+                  {group.txs.map((tx) => {
                   const isExpanded = expandedTxId === tx.id;
                   const isIncoming = tx.type === 'in';
                   const xmr402Info = xmr402Payments[tx.id];
@@ -301,40 +334,49 @@ export function TransactionLedger({ txs, subaddresses = [] }: TransactionLedgerP
                     <div key={tx.id} className="flex flex-col transition-all duration-200">
                       <div
                         onClick={() => toggleExpand(tx.id)}
-                        className={`grid grid-cols-12 px-4 py-3 items-center cursor-pointer hover:bg-xmr-green/5 transition-colors group ${isExpanded ? 'bg-xmr-green/5' : ''}`}
+                        className={`flex items-center px-4 py-3 cursor-pointer hover:bg-xmr-green/5 transition-colors group border-b border-xmr-border/5 relative ${isExpanded ? 'bg-xmr-green/5' : ''}`}
                       >
-                        <div className="col-span-3 flex items-center gap-2 text-xs font-black">
+                        {/* Color indicator bar on hover */}
+                        <div className={`absolute left-0 top-0 bottom-0 w-[2px] opacity-0 group-hover:opacity-100 transition-opacity ${isIncoming ? 'bg-xmr-green' : 'bg-xmr-accent'}`} />
+
+                        {/* Type indicator */}
+                        <div className={`w-7 h-7 rounded-md flex items-center justify-center mr-3 shrink-0 ${isIncoming ? 'bg-xmr-green/8 border border-xmr-green/20' : 'bg-xmr-accent/8 border border-xmr-accent/20'}`}>
                           {isIncoming ? (
-                            <ArrowDownLeft size={14} className="text-xmr-green" />
+                            <ArrowDownLeft size={13} className="text-xmr-green" />
                           ) : (
-                            <ArrowUpRight size={14} className="text-xmr-accent" />
-                          )}
-                          <span className={isIncoming ? 'text-xmr-green' : 'text-xmr-accent'}>
-                            {tx.type.toUpperCase()}
-                          </span>
-                          {ghostTrades[tx.id] && (
-                            <div className="flex items-center gap-1 px-1.5 py-0.5 bg-xmr-accent/10 border border-xmr-accent/20 rounded-sm">
-                              <Ghost size={10} className="text-xmr-accent" />
-                              <span className="text-[9px] text-xmr-accent font-black uppercase tracking-tighter">Ghost</span>
-                            </div>
-                          )}
-                          {xmr402Info && (
-                            <div className="flex items-center gap-1 px-1.5 py-0.5 bg-blue-500/10 border border-blue-500/20 rounded-sm">
-                              <ShieldCheck size={10} className="text-blue-500" />
-                              <span className="text-[9px] text-blue-500 font-black uppercase tracking-tighter">XMR402</span>
-                            </div>
+                            <ArrowUpRight size={13} className="text-xmr-accent" />
                           )}
                         </div>
 
-                        <div className={`col-span-4 text-xs font-black ${isIncoming ? 'text-xmr-green' : 'text-xmr-accent'}`}>
-                          {isIncoming ? '+' : '-'}{tx.amount} XMR
+                        {/* Info */}
+                        <div className="flex-1 min-w-0">
+                          <div className="flex items-center gap-2 text-[10px] font-black uppercase tracking-wide">
+                            <span className={isIncoming ? 'text-xmr-green' : 'text-xmr-accent'}>
+                              {isIncoming ? 'Received' : 'Dispatched'}
+                            </span>
+                            {ghostTrades[tx.id] && (
+                              <span className="text-[7px] px-1.5 py-0.5 bg-xmr-accent/10 border border-xmr-accent/20 rounded text-xmr-accent font-black tracking-wider">Ghost</span>
+                            )}
+                            {xmr402Info && (
+                              <span className="text-[7px] px-1.5 py-0.5 bg-blue-500/10 border border-blue-500/20 rounded text-blue-500 font-black tracking-wider">XMR402</span>
+                            )}
+                          </div>
+                          <div className="text-[9px] text-xmr-dim/40 mt-0.5 truncate">
+                            {isIncoming && tx.address ? `from ${tx.address.substring(0, 8)}...${tx.address.substring(tx.address.length - 6)}` : tx.destinations?.[0] ? `to ${tx.destinations[0].address.substring(0, 8)}...${tx.destinations[0].address.substring(tx.destinations[0].address.length - 6)}` : tx.type.toUpperCase()}
+                            {tx.fee && !isIncoming && ` · fee: ${tx.fee}`}
+                          </div>
                         </div>
 
-                        <div className="col-span-2 text-[11px] font-black opacity-30">
-                          [{tx.confirmations}]
+                        {/* Amount */}
+                        <div className="text-right shrink-0 ml-4">
+                          <div className={`text-[13px] font-black ${isIncoming ? 'text-xmr-green' : 'text-xmr-accent'}`}>
+                            {isIncoming ? '+' : '-'}{tx.amount}
+                          </div>
+                          <div className="text-[9px] text-xmr-dim/40 font-bold">XMR</div>
                         </div>
 
-                        <div className="col-span-3 text-right opacity-40 text-[11px] font-black font-mono">
+                        {/* Time */}
+                        <div className="w-16 text-right shrink-0 ml-3 text-[9px] text-xmr-dim/40 font-bold">
                           {getRelativeTime(tx.timestamp)}
                         </div>
                       </div>
@@ -554,7 +596,9 @@ export function TransactionLedger({ txs, subaddresses = [] }: TransactionLedgerP
                     </div>
                   );
                 })}
-              </div>
+                </div>
+              ))}
+            </div>
           )}
         </div>
       </div>

--- a/src/renderer/components/vault/VaultModals.tsx
+++ b/src/renderer/components/vault/VaultModals.tsx
@@ -49,7 +49,7 @@ export function VaultModals({
     <>
       {/* SEED MODAL */}
       {showSeed && (
-        <div className="fixed inset-0 z-[100] flex items-center justify-center p-6 bg-xmr-base/90 backdrop-blur-md animate-in fade-in duration-300">
+        <div className="fixed top-0 bottom-0 right-0 left-[14rem] z-[100] flex items-center justify-center p-6 bg-xmr-base/90 backdrop-blur-md animate-in fade-in duration-300">
           <div className="w-full max-w-lg bg-white text-black p-8 border-4 border-red-600 relative rounded-lg">
             <button onClick={onCloseSeed} className="absolute top-4 right-4 cursor-pointer"><X size={24} /></button>
             <div className="space-y-6 font-black">

--- a/src/renderer/contexts/VaultContext.tsx
+++ b/src/renderer/contexts/VaultContext.tsx
@@ -110,6 +110,7 @@ export function VaultProvider({ children }: { children: React.ReactNode }) {
   const [monero402Challenge, setMonero402Challenge] = useState<any>(null);
   const lastHeightRef = useRef<number>(0);
   const daemonHeightRef = useRef<number>(0);
+  const isRefreshing = useRef<boolean>(false);
 
   const determineSyncStatus = useCallback((height: number, daemonH: number) => {
     if (daemonH > 0) {
@@ -132,12 +133,19 @@ export function VaultProvider({ children }: { children: React.ReactNode }) {
 
   const refresh = useCallback(async () => {
     if (isLocked || isInitializing) return;
+    // Concurrency guard: skip if another refresh is already in-flight
+    if (isRefreshing.current) return;
+    isRefreshing.current = true;
 
     try {
+      // During active sync, only fetch accounts + balance — skip heavy calls
+      // (transfers, subaddresses, outputs) that compete with padded sync RPC
+      const isSyncActive = daemonHeightRef.current > 0 &&
+        (daemonHeightRef.current - lastHeightRef.current) > 5;
+
       const allAccs = await WalletService.getAccounts().catch(() => null);
       if (allAccs) {
         setAccounts(allAccs);
-        // 🛡️ Sync the global balance state for the currently selected account
         const currentAcc = allAccs.find(a => a.index === selectedAccountIndex);
         if (currentAcc) {
           setBalance({
@@ -147,49 +155,62 @@ export function VaultProvider({ children }: { children: React.ReactNode }) {
         }
       }
 
-      // Use allSettled: a single RPC failure (e.g. get_transfers over flaky Tor)
-      // must NOT prevent balance/height/addresses from displaying
-      const results = await Promise.allSettled([
-        WalletService.getBalance(selectedAccountIndex),
-        WalletService.getHeight(selectedAccountIndex),
-        WalletService.getTransactions(selectedAccountIndex),
-        WalletService.getSubaddresses(selectedAccountIndex),
-        WalletService.getOutputs(selectedAccountIndex)
-      ]);
+      if (isSyncActive) {
+        // Lightweight: only height check during sync, rest comes via wallet-events
+        const heightRes = await WalletService.getHeight(selectedAccountIndex).catch(() => null);
+        if (heightRes) {
+          setCurrentHeight(heightRes);
+          lastHeightRef.current = heightRes;
+          const { status: s, percent: p } = determineSyncStatus(heightRes, daemonHeightRef.current);
+          setStatus(s);
+          setSyncPercent(p);
+        }
+      } else {
+        // Full refresh when synced — all 5 calls in parallel
+        const results = await Promise.allSettled([
+          WalletService.getBalance(selectedAccountIndex),
+          WalletService.getHeight(selectedAccountIndex),
+          WalletService.getTransactions(selectedAccountIndex),
+          WalletService.getSubaddresses(selectedAccountIndex),
+          WalletService.getOutputs(selectedAccountIndex)
+        ]);
 
-      const [balRes, heightRes, txsRes, addrRes, outsRes] = results;
+        const [balRes, heightRes, txsRes, addrRes, outsRes] = results;
 
-      if (balRes.status === 'fulfilled') setBalance(balRes.value);
-      if (heightRes.status === 'fulfilled') {
-        const h = heightRes.value;
-        setCurrentHeight(h);
-        lastHeightRef.current = h;
-
-        // Recalculate sync status during refresh
-        const { status: s, percent: p } = determineSyncStatus(h, daemonHeightRef.current);
-        setStatus(s);
-        setSyncPercent(p);
+        if (balRes.status === 'fulfilled') setBalance(balRes.value);
+        if (heightRes.status === 'fulfilled') {
+          const h = heightRes.value;
+          setCurrentHeight(h);
+          lastHeightRef.current = h;
+          const { status: s, percent: p } = determineSyncStatus(h, daemonHeightRef.current);
+          setStatus(s);
+          setSyncPercent(p);
+        }
+        if (txsRes.status === 'fulfilled') setTxs(txsRes.value);
+        if (addrRes.status === 'fulfilled') {
+          setSubaddresses(addrRes.value);
+          setAddress(addrRes.value[0]?.address || '');
+        }
+        if (outsRes.status === 'fulfilled') setOutputs(outsRes.value);
       }
-      if (txsRes.status === 'fulfilled') setTxs(txsRes.value);
-      if (addrRes.status === 'fulfilled') {
-        setSubaddresses(addrRes.value);
-        setAddress(addrRes.value[0]?.address || '');
-      }
-      if (outsRes.status === 'fulfilled') setOutputs(outsRes.value);
-
     } catch (e: any) {
       console.warn("Sync gap detected:", e.message);
+    } finally {
+      isRefreshing.current = false;
     }
   }, [isLocked, isInitializing, selectedAccountIndex, determineSyncStatus]);
 
   // 🔄 Initial & Periodic Refresh
+  // During sync: lightweight poll every 45s. After sync: full refresh every 10s.
   useEffect(() => {
     if (!isLocked && !isInitializing) {
       refresh();
-      const timer = setInterval(refresh, 10000);
+      const isSyncing = status === 'SYNCING';
+      const interval = isSyncing ? 45000 : 10000;
+      const timer = setInterval(refresh, interval);
       return () => clearInterval(timer);
     }
-  }, [isLocked, isInitializing, refresh]);
+  }, [isLocked, isInitializing, refresh, status]);
 
   useEffect(() => {
     console.log("🔌 Initializing Core Log Listener...");
@@ -235,10 +256,23 @@ export function VaultProvider({ children }: { children: React.ReactNode }) {
           setSyncPercent(p);
         }
         if (event.type === 'BALANCE_CHANGED' && event.payload?.balance !== undefined) {
-          // 🛡️ Only update global state if the change belongs to the active account
-          // Since SyncWatcher currently emits for whichever account is active in RPC,
-          // we should double-check or just refresh to be safe.
-          refresh();
+          // During sync, just update balance inline instead of triggering a full
+          // refresh (5 RPC calls) that competes with padded sync for the wallet-rpc
+          const isSyncing = daemonHeightRef.current > 0 &&
+            (daemonHeightRef.current - lastHeightRef.current) > 5;
+          if (isSyncing) {
+            const pico = event.payload.balance;
+            const unlocked = event.payload.unlocked ?? pico;
+            const fmt = (v: number) => {
+              if (v < 0) return '0.0000';
+              const w = Math.floor(v / 1e12);
+              const f = v % 1e12;
+              return `${w}.${f.toString().padStart(12, '0')}`;
+            };
+            setBalance({ total: fmt(pico), unlocked: fmt(unlocked) });
+          } else {
+            refresh();
+          }
         }
       });
       return () => cleanup();

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -12,6 +12,7 @@
     --color-xmr-error: var(--error-color);
 
   --font-mono: "JetBrains Mono", "Fira Code", monospace;
+  --font-display: "DM Sans", system-ui, sans-serif;
 
   --radius: var(--skin-radius-md, 0.5rem);
   --radius-xs: var(--skin-radius-sm, 0.125rem);

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -6,8 +6,11 @@
     <link rel="icon" href="./logo-proposal-circle.svg" type="image/svg+xml">
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https: http://localhost:* http://127.0.0.1:* ws://localhost:* ws://127.0.0.1:*;"
+      content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self' https: http://localhost:* http://127.0.0.1:* ws://localhost:* ws://127.0.0.1:*;"
     />
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,wght@0,400;0,500;0,700;0,800;1,400&display=swap" rel="stylesheet">
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
## Summary
- Card-stack account switcher with nav arrows, inline quick actions, portfolio total
- Full-width account card layout with 2-column internal split
- Inline send/receive panels replace modal overlays
- Exodus-style one-step wallet creation for new users
- Sync RPC contention reduction (lightweight refresh during sync, per-chunk height estimation)
- Smart sync banner (only shows >1000 blocks behind)
- DM Sans display font for headlines/balances
- Date-grouped transaction ledger with color-coded indicators
- Pill-style tabs inside content border
- Modal centering offset for sidebar
- Fix Ghost exchange infinite subaddress loop

## Test plan
- [ ] Test account switching via card nav arrows and "All Accounts" dropdown
- [ ] Test inline send/receive panels (should render in tab content area, not as overlay)
- [ ] Test first-launch onboarding (should skip to password creation)
- [ ] Verify sync performance improvement
- [ ] Check modal centering with sidebar offset
- [ ] Test all three skins (terminal/clean/monero) for radius consistency

🤖 Generated with [Claude Code](https://claude.com/claude-code)