### PR TITLE
refactor: type safety and xmr-error theme consistency

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -412,7 +412,7 @@ function MainApp() {
         <div className="px-4 py-3 border-t border-xmr-border/20 bg-xmr-green/[0.02] space-y-2" style={{ WebkitAppRegion: 'no-drag' } as any}>
           {/* Lock + Console row */}
           <div className="flex gap-1.5">
-            <button onClick={lock} className="flex-grow flex items-center justify-center gap-1.5 py-2 bg-red-950/20 border border-red-900/50 text-red-500 hover:bg-red-500 hover:text-white transition-all cursor-pointer group uppercase text-[10px] font-black rounded-sm">
+            <button onClick={lock} className="flex-grow flex items-center justify-center gap-1.5 py-2 bg-xmr-error/5 border border-xmr-error/20 text-xmr-error hover:bg-xmr-error hover:text-xmr-base transition-all cursor-pointer group uppercase text-[10px] font-black rounded-sm">
               <Lock size={12} className="group-hover:scale-110 transition-transform" /> LOCK
             </button>
             <button onClick={() => setShowConsole(!showConsole)} className={`px-2.5 py-2 border transition-all cursor-pointer rounded-sm ${showConsole ? 'border-xmr-green text-xmr-green bg-xmr-green/10' : 'border-xmr-border text-xmr-dim hover:border-xmr-green'}`}>

--- a/src/renderer/components/HomeView.tsx
+++ b/src/renderer/components/HomeView.tsx
@@ -1,5 +1,5 @@
 import React, { Suspense } from 'react';
-import { Activity, BarChart3, Shield, Zap, Globe, Lock, Ghost, TrendingUp, AlertTriangle } from 'lucide-react';
+import { Activity, BarChart3, Globe, Lock, Ghost, TrendingUp, AlertTriangle } from 'lucide-react';
 import { useTheme } from '../hooks/useTheme';
 import { Card } from './Card';
 

--- a/src/renderer/components/SettingsView.tsx
+++ b/src/renderer/components/SettingsView.tsx
@@ -534,7 +534,7 @@ export function SettingsView() {
                 {localSettings.skin_background && (
                   <button
                     onClick={() => setLocalSettings({ ...localSettings, skin_background: '' })}
-                    className="px-4 py-2 bg-red-950/20 border border-red-900/30 hover:bg-red-900/50 text-red-500 text-xs font-black uppercase transition-colors cursor-pointer flex items-center gap-2"
+                    className="px-4 py-2 bg-xmr-error/5 border border-xmr-error/20 hover:bg-xmr-error/10 text-xmr-error text-xs font-black uppercase transition-colors cursor-pointer flex items-center gap-2"
                   >
                     <Trash2 size={12} /> Clear
                   </button>
@@ -628,10 +628,10 @@ export function SettingsView() {
 
         {/* ☢️ Danger Zone */}
         <section className="space-y-4 pt-4">
-          <h3 className="text-xs font-black text-red-500 flex items-center gap-2 uppercase"><ShieldAlert size={14} /> Dangerous_Sector</h3>
-          <Card noPadding={false} topGradientAccentColor='xmr-error' className="p-6 bg-red-950/10 border-red-900/30 flex items-center justify-between">
-            <div className="space-y-1"><span className="text-xs font-black text-red-500 uppercase">Nuclear_Burn_ID</span><p className="text-xs text-red-500/60 uppercase font-black">Erase local seed and vault keys forever.</p></div>
-            <button onClick={() => purgeIdentity(activeId)} className="px-4 py-2 border border-red-600 text-red-500 text-xs font-black hover:bg-red-600 hover:text-white transition-all uppercase cursor-pointer">Burn_Everything</button>
+          <h3 className="text-xs font-black text-xmr-error flex items-center gap-2 uppercase"><ShieldAlert size={14} /> Dangerous_Sector</h3>
+          <Card noPadding={false} topGradientAccentColor='xmr-error' className="p-6 bg-xmr-error/5 border-xmr-error/20 flex items-center justify-between">
+            <div className="space-y-1"><span className="text-xs font-black text-xmr-error uppercase">Nuclear_Burn_ID</span><p className="text-xs text-xmr-error/60 uppercase font-black">Erase local seed and vault keys forever.</p></div>
+            <button onClick={() => purgeIdentity(activeId)} className="px-4 py-2 border border-xmr-error/50 text-xmr-error text-xs font-black hover:bg-xmr-error hover:text-xmr-base transition-all uppercase cursor-pointer">Burn_Everything</button>
           </Card>
         </section>
       </div>

--- a/src/renderer/components/VaultView.tsx
+++ b/src/renderer/components/VaultView.tsx
@@ -1,13 +1,13 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { RefreshCw, Key, Send, Download, Wind, Loader2, Edit2, Scissors, MoreVertical, Plus, ChevronLeft, ChevronRight } from 'lucide-react';
-import { AddressBook } from './vault/AddressBook';
+import { AddressBook, Contact } from './vault/AddressBook';
 import { AddressList } from './vault/AddressList';
 import { CoinControl } from './vault/CoinControl';
 import { TransactionLedger } from './vault/TransactionLedger';
 import { VaultModals } from './vault/VaultModals';
 import { DispatchModal } from './vault/DispatchModal';
 import { ReceiveModal } from './vault/ReceiveModal';
-import { type VaultContextType } from '../contexts/VaultContext';
+import { type VaultContextType, type SubaddressInfo } from '../contexts/VaultContext';
 import { WalletService } from '../services/walletService';
 import { useFiatValue } from '../hooks/useFiatValue';
 
@@ -29,9 +29,9 @@ export function VaultView({ setView, vault, handleBurn, appConfig }: VaultViewPr
   const [tab, setTab] = useState<'ledger' | 'addresses' | 'coins' | 'contacts'>('ledger');
   const [modals, setModals] = useState({ seed: false, receive: false, send: false, splinter: false, churn: false });
   const [mnemonic, setMnemonic] = useState('');
-  const [contacts, setContacts] = useState<any[]>([]);
+  const [contacts, setContacts] = useState<Contact[]>([]);
   const [dispatchAddr, setDispatchAddr] = useState('');
-  const [selectedSubaddress, setSelectedSubaddress] = useState<any>(null);
+  const [selectedSubaddress, setSelectedSubaddress] = useState<SubaddressInfo | null>(null);
   const [dispatchSubIndex, setDispatchSubIndex] = useState<number | undefined>(undefined);
   const [showCardMenu, setShowCardMenu] = useState(false);
   const [showAccountList, setShowAccountList] = useState(false);
@@ -86,7 +86,7 @@ export function VaultView({ setView, vault, handleBurn, appConfig }: VaultViewPr
     return () => clearTimeout(t);
   }, [selectedAccountIndex]);
 
-  const saveContacts = async (updated: any[]) => {
+  const saveContacts = async (updated: Contact[]) => {
     setContacts(updated);
     const currentConfig = await window.api.getConfig();
     await window.api.saveConfigAndReload({

--- a/src/renderer/components/vault/AddressBook.tsx
+++ b/src/renderer/components/vault/AddressBook.tsx
@@ -3,8 +3,13 @@ import { Book, PlusCircle, X } from 'lucide-react';
 import { Card } from '../Card';
 import { TableHeader } from './TableHeader';
 
+export interface Contact {
+  name: string;
+  address: string;
+}
+
 interface AddressBookProps {
-  contacts: any[];
+  contacts: Contact[];
   onAddContact: (contact: { name: string; address: string }) => void;
   onRemoveContact: (index: number) => void;
   onDispatch: (address: string) => void;

--- a/src/renderer/components/vault/AddressList.tsx
+++ b/src/renderer/components/vault/AddressList.tsx
@@ -3,12 +3,13 @@ import { Copy, Edit2, Check, X, Wind, Send } from 'lucide-react';
 import { Card } from '../Card';
 import { TableHeader } from './TableHeader';
 import { AddressDisplay } from '../common/AddressDisplay';
+import { SubaddressInfo } from '../../contexts/VaultContext';
 
 interface AddressListProps {
-  subaddresses: any[];
+  subaddresses: SubaddressInfo[];
   handleCopy: (text: string) => void;
   onUpdateLabel: (index: number, label: string) => void;
-  onRowClick: (sub: any) => void;
+  onRowClick: (sub: SubaddressInfo) => void;
   onVanishSubaddress: (index: number) => Promise<void>;
   onSendFrom: (subaddressIndex: number) => void;
   isSyncing: boolean;
@@ -82,7 +83,7 @@ export function AddressList({
             </tr>
           </thead>
           <tbody className="text-xs font-black divide-y divide-xmr-border/5">
-            {subaddresses.map((s: any) => {
+            {subaddresses.map((s) => {
               const hasBalance = parseFloat(s.balance) > 0;
               const isVanishing = vanishingIndex === s.index;
 

--- a/src/renderer/components/vault/CoinControl.tsx
+++ b/src/renderer/components/vault/CoinControl.tsx
@@ -3,9 +3,10 @@ import { Coins, Shield, Lock as LockIcon, Wind, Send } from 'lucide-react';
 import { Card } from '../Card';
 import { TableHeader } from './TableHeader';
 import { useVault } from '../../contexts/VaultContext';
+import { WalletOutput } from '../../services/walletService';
 
 interface CoinControlProps {
-  outputs: any[];
+  outputs: WalletOutput[];
   onSendFromCoin?: (keyImage: string, amount: string) => void;
 }
 
@@ -42,7 +43,7 @@ export function CoinControl({ outputs, onSendFromCoin }: CoinControlProps) {
             </tr>
           </thead>
           <tbody className="text-xs font-black divide-y divide-xmr-border/5">
-            {outputs.map((o: any, i: number) => {
+            {outputs.map((o, i) => {
               const isProcessing = vanishingId === o.keyImage;
 
               return (

--- a/src/renderer/components/vault/DirectSendTab.tsx
+++ b/src/renderer/components/vault/DirectSendTab.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useRef } from 'react';
 import { Wallet, DollarSign, Send, Loader2, CheckCircle2, ChevronDown, ChevronUp, Coins, Copy, AlertTriangle, Info, ExternalLink } from 'lucide-react';
 import { useVault } from '../../contexts/VaultContext';
 import { useStats } from '../../hooks/useStats';
-import { WalletService } from '../../services/walletService';
+import { WalletService, WalletOutput } from '../../services/walletService';
 
 interface ParsedDest {
   address: string;
@@ -37,7 +37,7 @@ function parseMultiSend(text: string): { destinations: ParsedDest[]; errors: str
 interface DirectSendTabProps {
   initialAddress: string;
   sourceSubaddressIndex?: number;
-  outputs: any[];
+  outputs: WalletOutput[];
   onRequirePassword: (action: () => Promise<void>) => void;
   onClose: () => void;
 }
@@ -69,7 +69,7 @@ export function DirectSendTab({
   // --- Coin Control ---
   const [showCoinControl, setShowCoinControl] = useState(sourceSubaddressIndex !== undefined);
   const [selectedOutputs, setSelectedOutputs] = useState<Set<string>>(new Set());
-  const availableOutputs = outputs.filter((o: any) => o.isUnlocked);
+  const availableOutputs = outputs.filter((o) => o.isUnlocked);
 
   // --- xmr.bio Resolver ---
   const [bioProfile, setBioProfile] = useState<any>(null);
@@ -183,8 +183,8 @@ export function DirectSendTab({
   }, [getFeeEstimates]);
 
   const selectedTotal = availableOutputs
-    .filter((o: any) => selectedOutputs.has(o.keyImage))
-    .reduce((sum: number, o: any) => sum + parseFloat(o.amount || '0'), 0);
+    .filter((o) => selectedOutputs.has(o.keyImage))
+    .reduce((sum, o) => sum + parseFloat(o.amount || '0'), 0);
 
   const handleExecute = () => {
     if (sendMode === 'single') {

--- a/src/renderer/contexts/VaultContext.tsx
+++ b/src/renderer/contexts/VaultContext.tsx
@@ -1,5 +1,5 @@
 import React, { createContext, useContext, useState, useEffect, useCallback, useRef } from 'react';
-import { WalletService, Transaction } from '../services/walletService';
+import { WalletService, Transaction, WalletOutput } from '../services/walletService';
 
 export interface Identity { id: string; name: string; created: number; }
 export interface SubaddressInfo { index: number; address: string; label: string; balance: string; unlockedBalance: string; isUsed: boolean; }
@@ -35,7 +35,7 @@ export interface VaultContextType {
   identities: Identity[];
   activeId: string;
   isStagenet: boolean;
-  outputs: any[];
+  outputs: WalletOutput[];
   setSelectedAccountIndex: (index: number) => void;
   createAccount: (label: string) => Promise<void>;
   unlock: (password: string, newIdentityName?: string, restoreSeed?: string, restoreHeight?: number, seedLanguage?: string) => Promise<void>;
@@ -68,7 +68,7 @@ export interface VaultContextType {
     name?: string;
     returnUrl?: string;
   } | null;
-  setDeepLinkData: (data: any) => void;
+  setDeepLinkData: (data: VaultContextType['deepLinkData']) => void;
   clearDeepLinkData: () => void;
 
   // 🛡️ XMR402 Challenge Support
@@ -106,9 +106,9 @@ export function VaultProvider({ children }: { children: React.ReactNode }) {
   const [hasVaultFile, setHasVaultFile] = useState(false);
   const [isSending, setIsSending] = useState(false);
   const [isStagenet, setIsStagenet] = useState(false);
-  const [outputs, setOutputs] = useState<any[]>([]);
+  const [outputs, setOutputs] = useState<WalletOutput[]>([]);
   const [requestedAction, setRequestedAction] = useState<string | null>(null);
-  const [deepLinkData, setDeepLinkData] = useState<any>(null);
+  const [deepLinkData, setDeepLinkData] = useState<VaultContextType['deepLinkData']>(null);
   const [monero402Challenge, setMonero402Challenge] = useState<any>(null);
   const lastHeightRef = useRef<number>(0);
   const daemonHeightRef = useRef<number>(0);
@@ -596,7 +596,7 @@ export function VaultProvider({ children }: { children: React.ReactNode }) {
         const nextActiveId = current || (validIds.length > 0 ? validIds[0].id : '');
         setActiveId(nextActiveId);
         setHasVaultFile(validIds.length > 0 && !!nextActiveId);
-      } catch (err) { } finally {
+      } catch (err) { console.warn('Identity boot failed:', err); } finally {
         setIsAppLoading(false);
       }
     };

--- a/src/renderer/services/walletService.ts
+++ b/src/renderer/services/walletService.ts
@@ -1,6 +1,17 @@
 import { MoneroAccount } from '../contexts/VaultContext';
 import { RpcClient } from './rpcClient';
 
+export interface WalletOutput {
+  amount: string;
+  keyImage: string;
+  isUnlocked: boolean;
+  frozen: boolean;
+  spent: boolean;
+  subaddressIndex: number;
+  timestamp: number;
+  txid: string;
+}
+
 export interface Transaction {
   id: string;
   amount: string;
@@ -245,7 +256,7 @@ export const WalletService = {
   },
 
 
-  async getOutputs(accountIndex: number) {
+  async getOutputs(accountIndex: number): Promise<WalletOutput[]> {
     try {
       // 🚀 Use incoming_transfers to retrieve all available outputs
       const res = await RpcClient.call('incoming_transfers', {
@@ -254,7 +265,7 @@ export const WalletService = {
         verbose: true
       });
 
-      return (res.transfers || []).map((o: any) => ({
+      return (res.transfers || []).map((o: any): WalletOutput => ({
         amount: RpcClient.formatXmr(o.amount),
         keyImage: o.key_image,
         isUnlocked: o.unlocked,
@@ -263,7 +274,7 @@ export const WalletService = {
         subaddressIndex: o.subaddr_index.minor,
         timestamp: o.timestamp ? o.timestamp * 1000 : Date.now(),
         txid: o.txid
-      })).sort((a: any, b: any) => b.timestamp - a.timestamp);
+      })).sort((a: WalletOutput, b: WalletOutput) => b.timestamp - a.timestamp);
 
     } catch (e: any) {
       console.error("RPC_METHOD_ERROR: incoming_transfers failed.", e.message);


### PR DESCRIPTION
## Summary
- **Type safety**: Add `WalletOutput` and `Contact` interfaces, replacing `any[]` across 6 components (VaultContext, DirectSendTab, CoinControl, AddressList, AddressBook, VaultView)
- **Theme consistency**: Replace hardcoded `red-950/red-900/red-500` Tailwind colors with `xmr-error` theme token in lock button, danger zone, and skin clear button — now respects light/dark theme
- **Cleanup**: Remove unused `Zap`/`Shield` imports from HomeView, add `console.warn` to silent identity boot catch

## Test plan
- [ ] Verify lock button in sidebar renders with correct error color in both dark and light themes
- [ ] Verify Settings → Dangerous Sector section uses themed error colors
- [ ] Verify skin clear button uses themed error colors
- [ ] Confirm no TypeScript compilation errors (`npx tsc --noEmit` passes)
- [ ] Verify VaultView, DirectSendTab, CoinControl, AddressList still render correctly with typed props

🤖 Generated with [Claude Code](https://claude.com/claude-code)