### PR TITLE
refactor: use theme colors and fix silent error catches

### DIFF
--- a/src/main/SyncWatcher.ts
+++ b/src/main/SyncWatcher.ts
@@ -102,7 +102,7 @@ export class SyncWatcher {
         this.lastStoreTime = Date.now();
         this.emitLog('Watcher', 'info', '💾 Auto-saving wallet sync progress');
       }
-    } catch (e) { /* Ignore */ }
+    } catch (e) { console.warn('[SyncWatcher] Periodic store failed:', e); }
   }
 
   private emitLog(source: string, level: 'info' | 'error', message: string) {
@@ -123,7 +123,8 @@ export class SyncWatcher {
         this.lastDaemonHeightFetch = now;
       }
       return this.cachedDaemonHeight;
-    } catch {
+    } catch (e) {
+      console.warn('[SyncWatcher] Daemon height fetch failed:', e);
       return this.cachedDaemonHeight;
     }
   }
@@ -262,7 +263,7 @@ export class SyncWatcher {
           }
         });
       }
-    } catch (e) { /* Ignore */ }
+    } catch (e) { console.warn('[SyncWatcher] Sync status check failed:', e); }
   }
 
   private async checkBalance(): Promise<void> {
@@ -273,6 +274,6 @@ export class SyncWatcher {
         this.pushEvent({ type: 'BALANCE_CHANGED', payload: { balance: result.balance, unlocked: result.unlocked_balance } });
       }
       this.lastKnownBalance = result.balance;
-    } catch (e) { /* Ignore */ }
+    } catch (e) { console.warn('[SyncWatcher] Balance check failed:', e); }
   }
 }

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -91,7 +91,7 @@ function MainApp() {
         if (res.success && res.hasUpdate && res.latestVersion && res.releaseUrl) {
           setUpdateBanner({ show: true, version: res.latestVersion, url: res.releaseUrl });
         }
-      } catch (e) { }
+      } catch (e) { console.warn('[App] Update check failed:', e); }
     };
 
     // Delay check slightly so it doesn't interrupt the user's initial orientation

--- a/src/renderer/components/CurrencyInput.tsx
+++ b/src/renderer/components/CurrencyInput.tsx
@@ -164,7 +164,7 @@ export function CurrencyInput({
           <h3 className="font-bold text-xmr-green tracking-[0.2em] text-sm flex items-center gap-2">
             <Search size={14} /> SELECT_ASSET
           </h3>
-          <button onClick={() => setIsModalOpen(false)} className="text-xmr-dim hover:text-red-500 transition-colors">
+          <button onClick={() => setIsModalOpen(false)} className="text-xmr-dim hover:text-xmr-error transition-colors">
             <X size={20} />
           </button>
         </div>
@@ -251,7 +251,7 @@ export function CurrencyInput({
       <div className={`
         relative flex items-center bg-xmr-surface border rounded-sm transition-all duration-300 group
         ${error
-          ? 'border-red-500/50 shadow-[0_0_15px_rgba(239,68,68,0.1)]'
+          ? 'border-xmr-error/50 shadow-[0_0_15px_rgba(239,68,68,0.1)]'
           : 'border-xmr-border hover:border-xmr-green/50 focus-within:border-xmr-green focus-within:shadow-[0_0_20px_rgba(0,255,65,0.05)]'
         }
       `}>
@@ -314,7 +314,7 @@ export function CurrencyInput({
       </div>
 
       {error && (
-        <div className="text-red-500 text-xs mt-2 pl-1 font-bold animate-pulse flex items-center gap-1">
+        <div className="text-xmr-error text-xs mt-2 pl-1 font-bold animate-pulse flex items-center gap-1">
           !!! {error}
         </div>
       )}

--- a/src/renderer/components/ExchangeView.tsx
+++ b/src/renderer/components/ExchangeView.tsx
@@ -451,10 +451,10 @@ export function ExchangeView({ localXmrAddress }: ExchangeViewProps) {
                     </span>
                   </div>
                   <div className="flex items-center gap-1">
-                    {isPrivacy && <span className="text-[7px] font-bold uppercase px-1 py-0.5 bg-purple-500/10 text-purple-400 border border-purple-500/20 rounded-sm">NO-KYC</span>}
+                    {isPrivacy && <span className="text-[7px] font-bold uppercase px-1 py-0.5 bg-xmr-ghost/10 text-xmr-ghost border border-xmr-ghost/20 rounded-sm">NO-KYC</span>}
                     {route.bridgeBadge && <span className="text-[7px] font-bold uppercase px-1 py-0.5 bg-xmr-ghost/10 text-xmr-ghost border border-xmr-ghost/20 rounded-sm">{route.bridgeBadge}</span>}
                     {!isGhost && !route.fixed && <span className="text-[7px] font-bold uppercase px-1 py-0.5 bg-xmr-warning/10 text-xmr-warning border border-xmr-warning/20 rounded-sm">FLOAT</span>}
-                    {!isGhost && route.fixed && <span className="text-[7px] font-bold uppercase px-1 py-0.5 bg-cyan-500/10 text-cyan-400 border border-cyan-500/20 rounded-sm">FIXED</span>}
+                    {!isGhost && route.fixed && <span className="text-[7px] font-bold uppercase px-1 py-0.5 bg-xmr-green/10 text-xmr-green border border-xmr-green/20 rounded-sm">FIXED</span>}
                     {i === 0 && <span className="text-[7px] font-black uppercase px-1 py-0.5 bg-xmr-green/10 text-xmr-green border border-xmr-green/20 rounded-sm">{sortBy === 'rate' ? 'TOP' : sortBy === 'speed' ? 'FAST' : 'BEST'}</span>}
                   </div>
                 </div>

--- a/src/renderer/components/ExchangeView.tsx
+++ b/src/renderer/components/ExchangeView.tsx
@@ -139,7 +139,8 @@ export function ExchangeView({ localXmrAddress }: ExchangeViewProps) {
         const prefix = isGhost ? 'Ghost' : 'Swap';
         const addr = await getOrCreateSubaddress(prefix, subaddresses, createSubaddress);
         setDestAddress(addr || localXmrAddress);
-      } catch {
+      } catch (e) {
+        console.warn('[Exchange] Subaddress generation failed, using primary:', e);
         setDestAddress(localXmrAddress);
       } finally {
         generatingSubRef.current = false;
@@ -207,7 +208,7 @@ export function ExchangeView({ localXmrAddress }: ExchangeViewProps) {
             if (s === 'FINISHED') setStep('completed');
           }
         }
-      } catch { /* retry */ }
+      } catch (e) { console.warn('[Exchange] Poll failed, retrying:', e); }
     };
 
     poll();
@@ -237,7 +238,7 @@ export function ExchangeView({ localXmrAddress }: ExchangeViewProps) {
             setStep('completed');
           }
         }
-      } catch { /* retry */ }
+      } catch (e) { console.warn('[Exchange] Poll failed, retrying:', e); }
     };
 
     poll();
@@ -452,7 +453,7 @@ export function ExchangeView({ localXmrAddress }: ExchangeViewProps) {
                   <div className="flex items-center gap-1">
                     {isPrivacy && <span className="text-[7px] font-bold uppercase px-1 py-0.5 bg-purple-500/10 text-purple-400 border border-purple-500/20 rounded-sm">NO-KYC</span>}
                     {route.bridgeBadge && <span className="text-[7px] font-bold uppercase px-1 py-0.5 bg-xmr-ghost/10 text-xmr-ghost border border-xmr-ghost/20 rounded-sm">{route.bridgeBadge}</span>}
-                    {!isGhost && !route.fixed && <span className="text-[7px] font-bold uppercase px-1 py-0.5 bg-yellow-500/10 text-yellow-500 border border-yellow-500/20 rounded-sm">FLOAT</span>}
+                    {!isGhost && !route.fixed && <span className="text-[7px] font-bold uppercase px-1 py-0.5 bg-xmr-warning/10 text-xmr-warning border border-xmr-warning/20 rounded-sm">FLOAT</span>}
                     {!isGhost && route.fixed && <span className="text-[7px] font-bold uppercase px-1 py-0.5 bg-cyan-500/10 text-cyan-400 border border-cyan-500/20 rounded-sm">FIXED</span>}
                     {i === 0 && <span className="text-[7px] font-black uppercase px-1 py-0.5 bg-xmr-green/10 text-xmr-green border border-xmr-green/20 rounded-sm">{sortBy === 'rate' ? 'TOP' : sortBy === 'speed' ? 'FAST' : 'BEST'}</span>}
                   </div>
@@ -534,7 +535,7 @@ export function ExchangeView({ localXmrAddress }: ExchangeViewProps) {
         {logs.length === 0 ? (
           <div className="text-xmr-dim/30 text-center py-2 uppercase text-[9px]">Initializing...</div>
         ) : logs.map(log => (
-          <div key={log.id} className={`flex gap-2 ${log.type === 'error' ? 'text-xmr-error' : log.type === 'success' ? 'text-xmr-green' : log.type === 'warn' ? 'text-yellow-500' : 'text-xmr-dim'}`}>
+          <div key={log.id} className={`flex gap-2 ${log.type === 'error' ? 'text-xmr-error' : log.type === 'success' ? 'text-xmr-green' : log.type === 'warn' ? 'text-xmr-warning' : 'text-xmr-dim'}`}>
             <span className="text-xmr-dim/40 shrink-0">{log.time}</span>
             <span className="break-all">{log.text}</span>
           </div>

--- a/src/renderer/components/HomeView.tsx
+++ b/src/renderer/components/HomeView.tsx
@@ -123,7 +123,7 @@ export function HomeView({ setView, stats, loading }: HomeViewProps) {
          </button>
 
          <Card topGradientAccentColor="xmr-dim" className="flex flex-col justify-center relative overflow-hidden">
-            <div className="flex items-center gap-3 text-red-500 animate-pulse">
+            <div className="flex items-center gap-3 text-xmr-error animate-pulse">
                <AlertTriangle size={20} />
                <span className="text-xs font-black uppercase tracking-tighter">Sentinel_Active</span>
             </div>

--- a/src/renderer/components/SettingsView.tsx
+++ b/src/renderer/components/SettingsView.tsx
@@ -244,7 +244,7 @@ export function SettingsView() {
             </div>
 
             {updateResult.checked && (
-              <div className={`mt-4 p-4 border rounded-sm text-xs ${updateResult.error ? 'border-red-500/50 bg-red-500/10 text-red-400' : updateResult.hasUpdate ? 'border-xmr-accent/50 bg-xmr-accent/10 text-xmr-accent' : 'border-xmr-border bg-xmr-base text-xmr-dim'}`}>
+              <div className={`mt-4 p-4 border rounded-sm text-xs ${updateResult.error ? 'border-xmr-error/50 bg-xmr-error/10 text-xmr-error' : updateResult.hasUpdate ? 'border-xmr-accent/50 bg-xmr-accent/10 text-xmr-accent' : 'border-xmr-border bg-xmr-base text-xmr-dim'}`}>
                 {updateResult.error ? (
                   <div className="flex items-center gap-2"><ShieldAlert size={14} /> Update check failed: {updateResult.error}</div>
                 ) : updateResult.hasUpdate ? (
@@ -305,8 +305,8 @@ export function SettingsView() {
             <div className={`flex items-center justify-between p-4 border rounded-sm transition-all ${localSettings.network === 'stagenet' ? 'bg-xmr-accent/10 border-xmr-accent/40' : 'bg-xmr-green/5 border-xmr-border opacity-60'}`}>
               <div className="space-y-1">
                 <div className="flex items-center gap-2">
-                  <RefreshCw size={14} className={localSettings.network === 'stagenet' ? "text-orange-500 animate-spin" : "text-xmr-dim"} />
-                  <span className={`text-xs font-black uppercase ${localSettings.network === 'stagenet' ? 'text-orange-500' : ''}`}>Stagenet_Protocol</span>
+                  <RefreshCw size={14} className={localSettings.network === 'stagenet' ? "text-xmr-accent animate-spin" : "text-xmr-dim"} />
+                  <span className={`text-xs font-black uppercase ${localSettings.network === 'stagenet' ? 'text-xmr-accent' : ''}`}>Stagenet_Protocol</span>
                 </div>
                 <p className="text-xs text-xmr-dim uppercase font-black">Sandbox_Test_Network</p>
               </div>
@@ -414,10 +414,10 @@ export function SettingsView() {
                   <span>Encrypted_Vault_Storage</span>
                   <button onClick={() => appInfo?.walletsPath && handleReveal(appInfo.walletsPath)} className="flex items-center gap-1 hover:text-xmr-accent transition-colors cursor-pointer"><ExternalLink size={10} /> Reveal</button>
                 </div>
-                <div className="w-full bg-xmr-base border border-red-900/30 p-2 text-[11px] text-xmr-green opacity-70 font-mono select-all overflow-x-auto whitespace-nowrap custom-scrollbar">
+                <div className="w-full bg-xmr-base border border-xmr-error/30 p-2 text-[11px] text-xmr-green opacity-70 font-mono select-all overflow-x-auto whitespace-nowrap custom-scrollbar">
                   {appInfo?.walletsPath || 'Loading...'}
                 </div>
-                <p className="text-xs text-red-500/60 uppercase font-black flex items-center gap-1"><ShieldAlert size={8} /> Never share or modify these files manually. Backup regularly.</p>
+                <p className="text-xs text-xmr-error/60 uppercase font-black flex items-center gap-1"><ShieldAlert size={8} /> Never share or modify these files manually. Backup regularly.</p>
               </div>
             </div>
           </Card>
@@ -496,7 +496,7 @@ export function SettingsView() {
                 {localSettings.skin_background && (
                   <button
                     onClick={() => setLocalSettings({ ...localSettings, skin_background: '' })}
-                    className="px-4 py-2 bg-red-950/20 border border-red-900/30 hover:bg-red-900/50 text-red-500 text-xs font-black uppercase transition-colors cursor-pointer flex items-center gap-2"
+                    className="px-4 py-2 bg-xmr-error/10 border border-xmr-error/30 hover:bg-xmr-error/30 text-xmr-error text-xs font-black uppercase transition-colors cursor-pointer flex items-center gap-2"
                   >
                     <Trash2 size={12} /> Clear
                   </button>
@@ -590,10 +590,10 @@ export function SettingsView() {
 
         {/* ☢️ Danger Zone */}
         <section className="space-y-4 pt-4">
-          <h3 className="text-xs font-black text-red-500 flex items-center gap-2 uppercase"><ShieldAlert size={14} /> Dangerous_Sector</h3>
-          <Card noPadding={false} topGradientAccentColor='xmr-error' className="p-6 bg-red-950/10 border-red-900/30 flex items-center justify-between">
-            <div className="space-y-1"><span className="text-xs font-black text-red-500 uppercase">Nuclear_Burn_ID</span><p className="text-xs text-red-500/60 uppercase font-black">Erase local seed and vault keys forever.</p></div>
-            <button onClick={() => purgeIdentity(activeId)} className="px-4 py-2 border border-red-600 text-red-500 text-xs font-black hover:bg-red-600 hover:text-white transition-all uppercase cursor-pointer">Burn_Everything</button>
+          <h3 className="text-xs font-black text-xmr-error flex items-center gap-2 uppercase"><ShieldAlert size={14} /> Dangerous_Sector</h3>
+          <Card noPadding={false} topGradientAccentColor='xmr-error' className="p-6 bg-xmr-error/5 border-xmr-error/30 flex items-center justify-between">
+            <div className="space-y-1"><span className="text-xs font-black text-xmr-error uppercase">Nuclear_Burn_ID</span><p className="text-xs text-xmr-error/60 uppercase font-black">Erase local seed and vault keys forever.</p></div>
+            <button onClick={() => purgeIdentity(activeId)} className="px-4 py-2 border border-xmr-error text-xmr-error text-xs font-black hover:bg-xmr-error hover:text-white transition-all uppercase cursor-pointer">Burn_Everything</button>
           </Card>
         </section>
       </div>

--- a/src/renderer/components/SpreadChart.tsx
+++ b/src/renderer/components/SpreadChart.tsx
@@ -204,7 +204,7 @@ export default function SpreadChart() {
           ) : (
             <div className="flex flex-col">
               <div className="text-xs text-xmr-green font-black tracking-widest mb-1 flex items-center gap-2 uppercase">
-                <div className={`w-1.5 h-1.5 rounded-full ${isLoading ? 'bg-yellow-500' : 'bg-xmr-green animate-pulse'}`}></div>
+                <div className={`w-1.5 h-1.5 rounded-full ${isLoading ? 'bg-xmr-warning' : 'bg-xmr-green animate-pulse'}`}></div>
                 INTEL_FEED :: {isLoading ? 'SYNCING...' : 'LIVE'}
               </div>
               <div className="flex flex-wrap gap-x-3 gap-y-1 text-[11px] font-black uppercase">

--- a/src/renderer/components/SpreadChart.tsx
+++ b/src/renderer/components/SpreadChart.tsx
@@ -38,14 +38,24 @@ export default function SpreadChart() {
     dateStr: string;
   } | null>(null);
 
+  const root = getComputedStyle(document.documentElement);
+  const brandColor = root.getPropertyValue('--brand-color').trim();
+  const borderColor = root.getPropertyValue('--border-color').trim();
+  const textPrimary = root.getPropertyValue('--text-primary').trim();
+  const textDim = root.getPropertyValue('--text-dim').trim();
+  const chartLine = root.getPropertyValue('--chart-line').trim();
+  const chartAreaTop = root.getPropertyValue('--chart-area-top').trim();
+  const chartGrid = root.getPropertyValue('--chart-grid').trim();
+  const textAccent = root.getPropertyValue('--text-accent').trim();
+
   const colors = {
-    text: theme === 'light' ? '#111827' : '#00ff41',
-    grid: theme === 'light' ? 'rgba(0,0,0,0.05)' : 'rgba(20, 60, 20, 0.3)',
-    border: theme === 'light' ? '#cbd5e1' : '#004d13',
-    areaLine: theme === 'light' ? '#047857' : '#00ff41',
-    areaTop: theme === 'light' ? 'rgba(4, 120, 87, 0.1)' : 'rgba(0, 255, 65, 0.15)',
-    paperLine: theme === 'light' ? '#64748b' : '#ffffff',
-    liqLine: '#ea580c',
+    text: textPrimary || '#00ff41',
+    grid: chartGrid || 'rgba(20, 60, 20, 0.3)',
+    border: borderColor || '#004d13',
+    areaLine: chartLine || brandColor,
+    areaTop: chartAreaTop || 'rgba(0, 255, 65, 0.15)',
+    paperLine: textDim || '#64748b',
+    liqLine: textAccent || '#ea580c',
     nodeLine: '#0891b2',
     volColor: theme === 'light' ? 'rgba(4, 120, 87, 0.3)' : 'rgba(0, 50, 0, 0.5)',
   };
@@ -196,7 +206,7 @@ export default function SpreadChart() {
                   <>
                     <button onClick={() => toggleSeries('vol')} className={`transition-all border-l border-xmr-border/30 pl-3 ${visibleSeries.vol ? 'text-xmr-green' : 'text-xmr-dim opacity-30'}`}>TXs: {Math.floor(hoverData.txActivity || 0)}</button>
                     <button onClick={() => toggleSeries('liq')} className={`transition-all ${visibleSeries.liq ? 'text-xmr-accent' : 'text-xmr-dim opacity-30'}`}>LIQ: {Math.floor(hoverData.liquidity || 0)}</button>
-                    <button onClick={() => toggleSeries('nodes')} className={`transition-all ${visibleSeries.nodes ? 'text-cyan-500' : 'text-xmr-dim opacity-30'}`}>NODES: {Math.floor(hoverData.nodes || 0)}</button>
+                    <button onClick={() => toggleSeries('nodes')} className={`transition-all ${visibleSeries.nodes ? 'text-xmr-green opacity-70' : 'text-xmr-dim opacity-30'}`}>NODES: {Math.floor(hoverData.nodes || 0)}</button>
                   </>
                 )}
               </div>
@@ -214,7 +224,7 @@ export default function SpreadChart() {
                   <>
                     <button onClick={() => toggleSeries('vol')} className={`transition-all border-l border-xmr-border/30 pl-3 ${visibleSeries.vol ? 'text-xmr-green' : 'text-xmr-dim opacity-30'}`}>▮ VOL</button>
                     <button onClick={() => toggleSeries('liq')} className={`transition-all ${visibleSeries.liq ? 'text-xmr-accent' : 'text-xmr-dim opacity-30'}`}>~ LIQ</button>
-                    <button onClick={() => toggleSeries('nodes')} className={`transition-all ${visibleSeries.nodes ? 'text-cyan-500' : 'text-xmr-dim opacity-30'}`}>~ NODES</button>
+                    <button onClick={() => toggleSeries('nodes')} className={`transition-all ${visibleSeries.nodes ? 'text-xmr-green opacity-70' : 'text-xmr-dim opacity-30'}`}>~ NODES</button>
                   </>
                 )}
               </div>

--- a/src/renderer/components/VaultView.tsx
+++ b/src/renderer/components/VaultView.tsx
@@ -308,7 +308,7 @@ export function VaultView({ setView, vault, handleBurn, appConfig }: VaultViewPr
                       key={action.label}
                       onClick={action.onClick}
                       disabled={action.disabled}
-                      className="flex items-center gap-2 px-4 py-2 rounded-xl border border-xmr-green/20 bg-xmr-base/40 text-xmr-green hover:border-xmr-green/50 hover:bg-xmr-green/10 transition-all cursor-pointer disabled:opacity-30 disabled:cursor-not-allowed group"
+                      className="flex items-center gap-2 px-4 py-2 rounded-lg border border-xmr-green/20 bg-xmr-base/40 text-xmr-green hover:border-xmr-green/50 hover:bg-xmr-green/10 transition-all cursor-pointer disabled:opacity-30 disabled:cursor-not-allowed group"
                     >
                       <action.icon size={14} className={action.spin ? 'animate-spin' : ''} />
                       <span className="text-[9px] font-bold uppercase tracking-[0.12em] group-hover:text-xmr-green transition-colors">

--- a/src/renderer/components/VigilView.tsx
+++ b/src/renderer/components/VigilView.tsx
@@ -137,7 +137,7 @@ export function VigilView({ localXmrAddress }: VigilViewProps) {
     <div className={`
       border rounded-lg overflow-hidden backdrop-blur-md flex flex-col relative shadow-xl transition-all duration-500
       ${isDanger
-        ? 'bg-red-900/20 border-red-500/50 shadow-[0_0_50px_rgba(239,68,68,0.3)]'
+        ? 'bg-xmr-error/20 border-xmr-error/50 shadow-[0_0_50px_rgba(239,68,68,0.3)]'
         : 'bg-xmr-surface border-xmr-border'
       }
     `}>
@@ -145,19 +145,19 @@ export function VigilView({ localXmrAddress }: VigilViewProps) {
       {/* ─── Progress Bar ─── */}
       <div className="h-0.5 w-full bg-xmr-ghost/10">
         <div className={`h-full transition-all duration-1000 ease-in-out
-          ${isDanger ? 'bg-red-500 animate-pulse' : 'bg-xmr-ghost shadow-[0_0_10px_var(--color-xmr-ghost)]'}
+          ${isDanger ? 'bg-xmr-error animate-pulse' : 'bg-xmr-ghost shadow-[0_0_10px_var(--color-xmr-ghost)]'}
           ${progressWidth}
         `} />
       </div>
 
       {/* ─── Header ─── */}
       <div className={`px-4 py-2.5 border-b flex justify-between items-center transition-colors
-        ${isDanger ? 'bg-red-500/10 border-red-500/30' : 'bg-xmr-base/30 border-xmr-border'}
+        ${isDanger ? 'bg-xmr-error/10 border-xmr-error/30' : 'bg-xmr-base/30 border-xmr-border'}
       `}>
         <div className="flex items-center gap-2">
           <div className={`p-1.5 rounded border transition-colors
             ${isDanger
-              ? 'bg-red-500/20 border-red-500 text-red-500'
+              ? 'bg-xmr-error/20 border-xmr-error text-xmr-error'
               : 'bg-xmr-ghost/10 border-xmr-ghost/20 text-xmr-ghost'
             }
           `}>
@@ -173,13 +173,13 @@ export function VigilView({ localXmrAddress }: VigilViewProps) {
 
         <div className="flex items-center gap-2">
           {vigilState !== 'IDLE' && (
-            <Radio size={12} className={`${isDanger ? 'text-red-500 animate-ping' : 'text-xmr-green animate-pulse'}`} />
+            <Radio size={12} className={`${isDanger ? 'text-xmr-error animate-ping' : 'text-xmr-green animate-pulse'}`} />
           )}
           <span className="text-[10px] font-mono text-xmr-dim">
-            STATUS: <span className={`font-bold ${isDanger ? 'text-red-500' : 'text-current'}`}>{vigilState}</span>
+            STATUS: <span className={`font-bold ${isDanger ? 'text-xmr-error' : 'text-current'}`}>{vigilState}</span>
           </span>
           {wsConnected !== undefined && (
-            <div className={`w-1.5 h-1.5 rounded-full ${wsConnected ? 'bg-xmr-green' : 'bg-red-500'}`}
+            <div className={`w-1.5 h-1.5 rounded-full ${wsConnected ? 'bg-xmr-green' : 'bg-xmr-error'}`}
               title={wsConnected ? 'WebSocket Connected' : 'WebSocket Disconnected'}
             />
           )}
@@ -221,7 +221,7 @@ export function VigilView({ localXmrAddress }: VigilViewProps) {
         {/* EXECUTING: Spinner with logs */}
         {vigilState === 'EXECUTING' && (
           <div className="flex flex-col items-center justify-center min-h-[300px] space-y-6 animate-in fade-in">
-            <Loader2 size={48} className="text-red-500 animate-spin" />
+            <Loader2 size={48} className="text-xmr-error animate-spin" />
             <div className="text-xs font-mono text-current animate-pulse uppercase tracking-widest">
               EXECUTING TRADE...
             </div>
@@ -331,9 +331,9 @@ export function VigilView({ localXmrAddress }: VigilViewProps) {
         {/* ERROR: Error state */}
         {vigilState === 'ERROR' && (
           <div className="flex flex-col items-center justify-center min-h-[300px] space-y-6 animate-in fade-in">
-            <AlertTriangle size={48} className="text-red-500" />
+            <AlertTriangle size={48} className="text-xmr-error" />
             <div className="text-center space-y-2">
-              <h3 className="text-lg font-black uppercase tracking-widest text-red-500 font-mono">
+              <h3 className="text-lg font-black uppercase tracking-widest text-xmr-error font-mono">
                 VIGIL ERROR
               </h3>
               <p className="text-[10px] text-xmr-dim uppercase tracking-[0.2em]">
@@ -342,7 +342,7 @@ export function VigilView({ localXmrAddress }: VigilViewProps) {
             </div>
 
             {/* Error logs */}
-            <div className="w-full max-w-xl bg-xmr-base border border-red-500/20 rounded-lg p-3 max-h-[150px] overflow-y-auto font-mono text-[10px] space-y-0.5 custom-scrollbar">
+            <div className="w-full max-w-xl bg-xmr-base border border-xmr-error/20 rounded-lg p-3 max-h-[150px] overflow-y-auto font-mono text-[10px] space-y-0.5 custom-scrollbar">
               {logs.filter((l) => l.type === 'error').map((log) => (
                 <div key={log.id} className="text-xmr-error">
                   <span className="text-xmr-dim/40 mr-2">{log.time}</span>

--- a/src/renderer/components/auth/AuthForm.tsx
+++ b/src/renderer/components/auth/AuthForm.tsx
@@ -119,7 +119,7 @@ export function AuthForm({
         </div>
       )}
 
-      {error && <div className="p-3 bg-red-900/20 border border-red-600/50 text-red-500 text-xs font-black uppercase flex items-center gap-2 animate-shake"><Skull size={14} /> {error}</div>}
+      {error && <div className="p-3 bg-xmr-error/10 border border-xmr-error/50 text-xmr-error text-xs font-black uppercase flex items-center gap-2 animate-shake"><Skull size={14} /> {error}</div>}
 
       {isProcessing && logs.length > 0 && (
         <div className="p-3 bg-xmr-green/5 border border-xmr-green/10 rounded-sm space-y-1 overflow-hidden">

--- a/src/renderer/components/auth/IdentitySwitcher.tsx
+++ b/src/renderer/components/auth/IdentitySwitcher.tsx
@@ -81,7 +81,7 @@ export function IdentitySwitcher({ identities, activeId, onSwitchIdentity, onSta
                       onPurge(id.id);
                     }
                   }}
-                  className="px-2 border border-red-900/20 text-red-900/40 hover:border-red-600 hover:text-red-600 hover:bg-red-600/5 transition-all cursor-pointer"
+                  className="px-2 border border-xmr-error/20 text-xmr-error/40 hover:border-xmr-error hover:text-xmr-error hover:bg-xmr-error/5 transition-all cursor-pointer"
                 >
                   <Trash2 size={12} />
                 </button>

--- a/src/renderer/components/common/XMR402Modal.tsx
+++ b/src/renderer/components/common/XMR402Modal.tsx
@@ -155,7 +155,7 @@ export const XMR402Modal: React.FC = () => {
                 <p className="text-[10px] text-xmr-dim uppercase tracking-widest font-black">XMR402 // Tactical Execution Request</p>
               </div>
             </div>
-            <button onClick={handleDeny} className="text-xmr-dim hover:text-red-500 transition-colors cursor-pointer">
+            <button onClick={handleDeny} className="text-xmr-dim hover:text-xmr-error transition-colors cursor-pointer">
               <X size={20} />
             </button>
           </div>
@@ -174,7 +174,7 @@ export const XMR402Modal: React.FC = () => {
               </div>
               <div className="text-right">
                 <div className="text-[10px] text-xmr-dim uppercase font-black tracking-widest">Network</div>
-                <div className={`text-[10px] font-black uppercase ${isStagenet ? 'text-orange-500' : 'text-xmr-green'}`}>
+                <div className={`text-[10px] font-black uppercase ${isStagenet ? 'text-xmr-accent' : 'text-xmr-green'}`}>
                   {isStagenet ? 'STAGENET' : 'MAINNET'}
                 </div>
               </div>
@@ -266,7 +266,7 @@ export const XMR402Modal: React.FC = () => {
                         <span>{activeAccount?.label || 'Account_0'}</span>
                         {showAccountSelector ? <ChevronUp size={10} /> : <ChevronDown size={10} />}
                       </div>
-                      <span className={Number(activeAccount?.unlockedBalance) < Number(amount) ? 'text-red-500 animate-pulse' : 'text-xmr-green'}>
+                      <span className={Number(activeAccount?.unlockedBalance) < Number(amount) ? 'text-xmr-error animate-pulse' : 'text-xmr-green'}>
                         Balance: {activeAccount?.unlockedBalance || '0.0000'} XMR
                       </span>
                     </div>
@@ -296,7 +296,7 @@ export const XMR402Modal: React.FC = () => {
                                   <span className="opacity-50">#{acc.index}</span>
                                   {acc.label}
                                 </div>
-                                <span className={Number(acc.unlockedBalance) < Number(amount) ? 'text-red-500/50' : 'text-xmr-green/70'}>
+                                <span className={Number(acc.unlockedBalance) < Number(amount) ? 'text-xmr-error/50' : 'text-xmr-green/70'}>
                                   {acc.unlockedBalance} XMR
                                 </span>
                               </button>
@@ -321,7 +321,7 @@ export const XMR402Modal: React.FC = () => {
                     />
                   </div>
                   {error && (
-                    <div className="flex items-center gap-2 text-red-500 text-[10px] font-black uppercase italic animate-pulse">
+                    <div className="flex items-center gap-2 text-xmr-error text-[10px] font-black uppercase italic animate-pulse">
                       <AlertCircle size={12} /> {error}
                     </div>
                   )}
@@ -341,7 +341,7 @@ export const XMR402Modal: React.FC = () => {
                   </button>
                   <button
                     onClick={handleDeny}
-                    className="px-6 py-4 border border-xmr-border text-xmr-dim font-black uppercase text-xs tracking-widest hover:border-red-500 hover:text-red-500 transition-all cursor-pointer"
+                    className="px-6 py-4 border border-xmr-border text-xmr-dim font-black uppercase text-xs tracking-widest hover:border-xmr-error hover:text-xmr-error transition-all cursor-pointer"
                   >
                     Deny
                   </button>

--- a/src/renderer/components/vault/AddressBook.tsx
+++ b/src/renderer/components/vault/AddressBook.tsx
@@ -31,7 +31,7 @@ export function AddressBook({ contacts, onAddContact, onRemoveContact, onDispatc
                 <div key={i} className="p-4 border border-xmr-border/20 bg-xmr-green/[0.02] flex flex-col gap-3 relative group">
                   <button 
                     onClick={() => onRemoveContact(i)} 
-                    className="absolute top-2 right-2 text-red-900 opacity-0 group-hover:opacity-100 transition-all hover:text-red-500 cursor-pointer"
+                    className="absolute top-2 right-2 text-xmr-error/40 opacity-0 group-hover:opacity-100 transition-all hover:text-xmr-error cursor-pointer"
                   >
                     <X size={12}/>
                   </button>

--- a/src/renderer/components/vault/AddressList.tsx
+++ b/src/renderer/components/vault/AddressList.tsx
@@ -105,7 +105,7 @@ export function AddressList({
                           className="bg-xmr-base border border-xmr-green/50 text-xs px-2 py-1 outline-none text-xmr-green w-32"
                         />
                         <button onClick={saveEdit} className="text-xmr-green hover:scale-110 transition-transform"><Check size={12} /></button>
-                        <button onClick={() => setEditingIndex(null)} className="text-red-500 hover:scale-110 transition-transform"><X size={12} /></button>
+                        <button onClick={() => setEditingIndex(null)} className="text-xmr-error hover:scale-110 transition-transform"><X size={12} /></button>
                       </div>
                     ) : (
                       <div className="flex items-center gap-2">

--- a/src/renderer/components/vault/ChurnModal.tsx
+++ b/src/renderer/components/vault/ChurnModal.tsx
@@ -66,7 +66,7 @@ export function ChurnModal({ onClose, onChurn, unlockedBalance }: ChurnModalProp
             </div>
           </div>
 
-          {error && <div className="text-red-500 text-xs font-mono">{error}</div>}
+          {error && <div className="text-xmr-error text-xs font-mono">{error}</div>}
 
           <button
             onClick={handleSubmit}

--- a/src/renderer/components/vault/ChurnModal.tsx
+++ b/src/renderer/components/vault/ChurnModal.tsx
@@ -52,16 +52,16 @@ export function ChurnModal({ onClose, onChurn, unlockedBalance }: ChurnModalProp
 
           <div className="flex items-center justify-center gap-4 text-xmr-green py-4 opacity-80">
             <div className="flex flex-col gap-2">
-              <div className="w-8 h-8 rounded-full border-2 border border-xmr-green bg-xmr-green/10 flex items-center justify-center"><span className="text-[10px]">10</span></div>
-              <div className="w-8 h-8 rounded-full border-2 border border-xmr-green bg-xmr-green/10 flex items-center justify-center"><span className="text-[10px]">10</span></div>
-              <div className="w-8 h-8 rounded-full border-2 border border-xmr-green bg-xmr-green/10 flex items-center justify-center"><span className="text-[10px]">10</span></div>
+              <div className="w-8 h-8 rounded-full border-2 border-xmr-green bg-xmr-green/10 flex items-center justify-center"><span className="text-[10px]">10</span></div>
+              <div className="w-8 h-8 rounded-full border-2 border-xmr-green bg-xmr-green/10 flex items-center justify-center"><span className="text-[10px]">10</span></div>
+              <div className="w-8 h-8 rounded-full border-2 border-xmr-green bg-xmr-green/10 flex items-center justify-center"><span className="text-[10px]">10</span></div>
             </div>
             <div className="flex flex-col gap-2">
               <div className="h-0.5 w-12 bg-xmr-green/50 text-transparent">_</div>
               <div className="h-0.5 w-12 bg-xmr-green/50 text-transparent">_</div>
               <div className="h-0.5 w-12 bg-xmr-green/50 text-transparent">_</div>
             </div>
-            <div className="w-16 h-16 rounded-full border-4 border border-xmr-green bg-xmr-green/20 flex items-center justify-center animate-pulse shadow-[0_0_15px_rgba(0,255,0,0.4)]">
+            <div className="w-16 h-16 rounded-full border-4 border-xmr-green bg-xmr-green/20 flex items-center justify-center animate-pulse shadow-[0_0_15px_var(--brand-color)]">
               <span className="font-mono font-black text-sm">30</span>
             </div>
           </div>

--- a/src/renderer/components/vault/DirectSendTab.tsx
+++ b/src/renderer/components/vault/DirectSendTab.tsx
@@ -172,7 +172,7 @@ export function DirectSendTab({
           setFeeEstimates(mapped);
         }
       } catch (e) {
-        // silent fail
+        console.warn('[DirectSend] Fee estimate failed:', e);
       } finally {
         isFetchingFees.current = false;
         timer = setTimeout(fetchFees, 10000);
@@ -339,7 +339,7 @@ export function DirectSendTab({
                 <Wallet size={10} /> Destination
                 {isResolvingBio && <Loader2 size={10} className="animate-spin text-xmr-accent ml-1" />}
               </label>
-              {isBanned && <span className="text-xs text-red-500 animate-pulse uppercase">Intercepted</span>}
+              {isBanned && <span className="text-xs text-xmr-error animate-pulse uppercase">Intercepted</span>}
             </div>
             <input
               type="text"
@@ -347,7 +347,7 @@ export function DirectSendTab({
               onChange={(e) => setDestAddr(e.target.value)}
               placeholder="4... / 8... / @xbtoshi"
               className={`w-full bg-xmr-base border p-3 text-xs text-xmr-green focus:border-xmr-accent outline-none transition-colors ${
-                isBanned ? 'border-red-600' : 'border-xmr-border'
+                isBanned ? 'border-xmr-error' : 'border-xmr-border'
               }`}
             />
 
@@ -467,7 +467,7 @@ export function DirectSendTab({
             </div>
           )}
           {parsed.errors.length > 0 && (
-            <div className="text-xs text-red-500 space-y-0.5">
+            <div className="text-xs text-xmr-error space-y-0.5">
               {parsed.errors.map((e, i) => (
                 <div key={i}>{e}</div>
               ))}
@@ -597,7 +597,7 @@ export function DirectSendTab({
         onClick={handleExecute}
         className={`w-full py-4 font-black uppercase tracking-[0.3em] transition-all flex items-center justify-center gap-3 mt-2 cursor-pointer ${
           isBanned && sendMode === 'single'
-            ? 'bg-red-950 text-red-500 cursor-not-allowed'
+            ? 'bg-xmr-error/10 text-xmr-error cursor-not-allowed'
             : 'bg-xmr-accent text-xmr-base hover:bg-xmr-green hover:text-xmr-base disabled:opacity-50 disabled:cursor-not-allowed'
         }`}
       >

--- a/src/renderer/components/vault/DispatchPasswordGate.tsx
+++ b/src/renderer/components/vault/DispatchPasswordGate.tsx
@@ -34,10 +34,10 @@ export function DispatchPasswordGate({
         }}
         placeholder="••••••••••••"
         className={`w-full max-w-xs bg-xmr-base border p-3 text-xl font-black text-xmr-green text-center focus:border-xmr-accent outline-none transition-all ${
-          passwordError ? 'border-red-600' : 'border-xmr-border'
+          passwordError ? 'border-xmr-error' : 'border-xmr-border'
         }`}
       />
-      {passwordError && <div className="text-[11px] text-red-500 uppercase mt-2 animate-pulse">{passwordError}</div>}
+      {passwordError && <div className="text-[11px] text-xmr-error uppercase mt-2 animate-pulse">{passwordError}</div>}
       <div className="flex gap-3 mt-6 w-full max-w-xs">
         <button
           onClick={onCancel}

--- a/src/renderer/components/vault/GhostSendTab.tsx
+++ b/src/renderer/components/vault/GhostSendTab.tsx
@@ -171,8 +171,8 @@ export function GhostSendTab({ onRequirePassword, onClose }: GhostSendTabProps) 
               setGhostPhase('error');
               if (pollingRef.current) clearInterval(pollingRef.current);
             }
-          } catch {
-            /* swallow polling errors */
+          } catch (e) {
+            console.warn('[GhostSend] Poll failed, retrying:', e);
           }
         }, 10000);
       } catch (e: any) {
@@ -216,7 +216,7 @@ export function GhostSendTab({ onRequirePassword, onClose }: GhostSendTabProps) 
               </label>
               {ghostReceiverAddr.length > 0 && !isGhostAddrValidating && (
                 <span
-                  className={`text-xs uppercase tracking-widest ${isGhostAddrValid ? 'text-xmr-green' : 'text-red-500 animate-pulse'
+                  className={`text-xs uppercase tracking-widest ${isGhostAddrValid ? 'text-xmr-green' : 'text-xmr-error animate-pulse'
                     }`}
                 >
                   {isGhostAddrValid ? 'Valid Format' : ghostAddrError || 'Invalid Format'}
@@ -228,7 +228,7 @@ export function GhostSendTab({ onRequirePassword, onClose }: GhostSendTabProps) 
               value={ghostReceiverAddr}
               onChange={(e) => setGhostReceiverAddr(e.target.value)}
               placeholder={`${ghostCurrency?.ticker.toUpperCase() || 'Asset'} address`}
-              className={`w-full bg-xmr-base border p-3 text-xs text-xmr-green focus:border-xmr-accent outline-none transition-colors ${ghostReceiverAddr.length > 0 && isGhostAddrValid === false ? 'border-red-600' : 'border-xmr-border'
+              className={`w-full bg-xmr-base border p-3 text-xs text-xmr-green focus:border-xmr-accent outline-none transition-colors ${ghostReceiverAddr.length > 0 && isGhostAddrValid === false ? 'border-xmr-error' : 'border-xmr-border'
                 }`}
             />
           </div>
@@ -424,8 +424,8 @@ export function GhostSendTab({ onRequirePassword, onClose }: GhostSendTabProps) 
 
       {ghostPhase === 'error' && (
         <div className="py-12 flex flex-col items-center gap-4 text-center">
-          <AlertTriangle size={48} className="text-red-500" />
-          <div className="text-sm uppercase text-red-500 font-black">Ghost Send Failed</div>
+          <AlertTriangle size={48} className="text-xmr-error" />
+          <div className="text-sm uppercase text-xmr-error font-black">Ghost Send Failed</div>
           <div className="text-[11px] text-xmr-dim">{ghostError}</div>
           <button
             onClick={resetGhost}

--- a/src/renderer/components/vault/SplinterModal.tsx
+++ b/src/renderer/components/vault/SplinterModal.tsx
@@ -84,7 +84,7 @@ export function SplinterModal({ onClose, onSplinter, unlockedBalance }: Splinter
             />
           </div>
 
-          {error && <div className="text-red-500 text-xs font-mono">{error}</div>}
+          {error && <div className="text-xmr-error text-xs font-mono">{error}</div>}
         </div>
 
         {/* Sticky footer button */}

--- a/src/renderer/components/vault/SplinterModal.tsx
+++ b/src/renderer/components/vault/SplinterModal.tsx
@@ -57,7 +57,7 @@ export function SplinterModal({ onClose, onSplinter, unlockedBalance }: Splinter
           </div>
 
           <div className="flex items-center justify-center gap-4 text-xmr-accent py-4 opacity-80">
-            <div className="w-16 h-16 rounded-full border-4 border border-xmr-accent bg-xmr-accent/20 flex items-center justify-center animate-pulse shadow-[0_0_15px_rgba(255,255,255,0.4)]">
+            <div className="w-16 h-16 rounded-full border-4 border-xmr-accent bg-xmr-accent/20 flex items-center justify-center animate-pulse shadow-[0_0_15px_var(--text-accent)]">
                <span className="font-mono font-black text-sm">100</span>
             </div>
             <div className="flex flex-col gap-2">
@@ -66,9 +66,9 @@ export function SplinterModal({ onClose, onSplinter, unlockedBalance }: Splinter
               <div className="h-0.5 w-12 bg-xmr-accent/50 text-transparent">_</div>
             </div>
             <div className="flex flex-col gap-2">
-              <div className="w-8 h-8 rounded-full border-2 border border-xmr-accent bg-xmr-accent/10 flex items-center justify-center"><span className="text-[10px]">33</span></div>
-              <div className="w-8 h-8 rounded-full border-2 border border-xmr-accent bg-xmr-accent/10 flex items-center justify-center"><span className="text-[10px]">33</span></div>
-              <div className="w-8 h-8 rounded-full border-2 border border-xmr-accent bg-xmr-accent/10 flex items-center justify-center"><span className="text-[10px]">34</span></div>
+              <div className="w-8 h-8 rounded-full border-2 border-xmr-accent bg-xmr-accent/10 flex items-center justify-center"><span className="text-[10px]">33</span></div>
+              <div className="w-8 h-8 rounded-full border-2 border-xmr-accent bg-xmr-accent/10 flex items-center justify-center"><span className="text-[10px]">33</span></div>
+              <div className="w-8 h-8 rounded-full border-2 border-xmr-accent bg-xmr-accent/10 flex items-center justify-center"><span className="text-[10px]">34</span></div>
             </div>
           </div>
 

--- a/src/renderer/components/vault/TransactionLedger.tsx
+++ b/src/renderer/components/vault/TransactionLedger.tsx
@@ -279,13 +279,13 @@ export function TransactionLedger({ txs, subaddresses = [] }: TransactionLedgerP
                 </div>
 
                 {verifyResult && (
-                  <div className={`p-3 border rounded-sm animate-in zoom-in-95 duration-200 ${verifyResult.good === false ? 'bg-red-500/10 border-red-500/30' : 'bg-xmr-green/10 border-xmr-green/30'}`}>
+                  <div className={`p-3 border rounded-sm animate-in zoom-in-95 duration-200 ${verifyResult.good === false ? 'bg-xmr-error/10 border-xmr-error/30' : 'bg-xmr-green/10 border-xmr-green/30'}`}>
                     <div className="flex items-start gap-3">
-                      <div className={`mt-0.5 p-1 rounded-full ${verifyResult.good === false ? 'bg-red-500/20 text-red-500' : 'bg-xmr-green/20 text-xmr-green'}`}>
+                      <div className={`mt-0.5 p-1 rounded-full ${verifyResult.good === false ? 'bg-xmr-error/20 text-xmr-error' : 'bg-xmr-green/20 text-xmr-green'}`}>
                         {verifyResult.good === false ? <ShieldAlert size={16} /> : <CheckCircle size={16} />}
                       </div>
                       <div className="flex-grow space-y-1">
-                        <div className={`text-[11px] font-black uppercase tracking-wider ${verifyResult.good === false ? 'text-red-500' : 'text-xmr-green'}`}>
+                        <div className={`text-[11px] font-black uppercase tracking-wider ${verifyResult.good === false ? 'text-xmr-error' : 'text-xmr-green'}`}>
                           {verifyResult.good === false ? 'Verification Failed' : 'Payment Verified'}
                         </div>
                         <div className="grid grid-cols-2 gap-2 text-[10px]">
@@ -464,8 +464,8 @@ export function TransactionLedger({ txs, subaddresses = [] }: TransactionLedgerP
                               )}
                               {tx.doubleSpendSeen && (
                                 <div className="space-y-1">
-                                  <label className="text-xs text-red-500 uppercase font-black tracking-widest block">DoubleSpend_Alert</label>
-                                  <span className="text-xs font-black text-red-500 animate-pulse">WARNING: CONFLICT DETECTED</span>
+                                  <label className="text-xs text-xmr-error uppercase font-black tracking-widest block">DoubleSpend_Alert</label>
+                                  <span className="text-xs font-black text-xmr-error animate-pulse">WARNING: CONFLICT DETECTED</span>
                                 </div>
                               )}
                             </div>

--- a/src/renderer/components/vault/TransactionLedger.tsx
+++ b/src/renderer/components/vault/TransactionLedger.tsx
@@ -291,11 +291,11 @@ export function TransactionLedger({ txs, subaddresses = [] }: TransactionLedgerP
                         <div className="grid grid-cols-2 gap-2 text-[10px]">
                           <div className="flex flex-col">
                             <span className="text-xmr-dim font-bold uppercase text-[9px]">Amount_Received</span>
-                            <span className="text-white font-mono">{verifyResult.received} XMR</span>
+                            <span className="text-xmr-green font-mono">{verifyResult.received} XMR</span>
                           </div>
                           <div className="flex flex-col">
                             <span className="text-xmr-dim font-bold uppercase text-[9px]">Confirmations</span>
-                            <span className="text-white font-mono">{verifyResult.confirmations}</span>
+                            <span className="text-xmr-green font-mono">{verifyResult.confirmations}</span>
                           </div>
                         </div>
                         {verifyResult.inPool && (
@@ -358,7 +358,7 @@ export function TransactionLedger({ txs, subaddresses = [] }: TransactionLedgerP
                               <span className="text-[7px] px-1.5 py-0.5 bg-xmr-accent/10 border border-xmr-accent/20 rounded text-xmr-accent font-black tracking-wider">Ghost</span>
                             )}
                             {xmr402Info && (
-                              <span className="text-[7px] px-1.5 py-0.5 bg-blue-500/10 border border-blue-500/20 rounded text-blue-500 font-black tracking-wider">XMR402</span>
+                              <span className="text-[7px] px-1.5 py-0.5 bg-xmr-warning/10 border border-xmr-warning/20 rounded text-xmr-warning font-black tracking-wider">XMR402</span>
                             )}
                           </div>
                           <div className="text-[9px] text-xmr-dim/40 mt-0.5 truncate">
@@ -386,10 +386,10 @@ export function TransactionLedger({ txs, subaddresses = [] }: TransactionLedgerP
                         <div className="px-4 py-4 bg-xmr-green/5 border-t border-b border-xmr-green/10 space-y-4 animate-in fade-in slide-in-from-top-2 duration-300">
                           {/* XMR402 Panel */}
                           {xmr402Info && (
-                            <div className="p-3 bg-blue-500/10 border border-blue-500/20 rounded-sm flex justify-between items-center">
+                            <div className="p-3 bg-xmr-warning/10 border border-xmr-warning/20 rounded-sm flex justify-between items-center">
                               <div>
-                                <div className="text-[9px] text-blue-500 uppercase font-black tracking-widest">XMR402 Protocol Executed</div>
-                                <div className="text-xs text-white font-mono break-all opacity-80 mt-1">Nonce: {xmr402Info.nonce}</div>
+                                <div className="text-[9px] text-xmr-warning uppercase font-black tracking-widest">XMR402 Protocol Executed</div>
+                                <div className="text-xs text-xmr-green font-mono break-all opacity-80 mt-1">Nonce: {xmr402Info.nonce}</div>
                               </div>
                               {xmr402Info.returnUrl && (
                                 <button
@@ -400,7 +400,7 @@ export function TransactionLedger({ txs, subaddresses = [] }: TransactionLedgerP
                                     if (xmr402Info.proof) callbackUrl.searchParams.set('xmr402_proof', xmr402Info.proof);
                                     (window as any).api.openExternal(callbackUrl.toString());
                                   }}
-                                  className="shrink-0 ml-4 px-3 py-1.5 bg-blue-500 hover:bg-blue-600 text-white text-[10px] font-black uppercase tracking-wider rounded-sm transition-colors cursor-pointer flex items-center gap-1 shadow-[0_0_10px_rgba(59,130,246,0.2)]"
+                                  className="shrink-0 ml-4 px-3 py-1.5 bg-xmr-warning hover:opacity-90 text-xmr-base text-[10px] font-black uppercase tracking-wider rounded-sm transition-colors cursor-pointer flex items-center gap-1 shadow-[0_0_10px_var(--warning-color)]"
                                 >
                                   <ExternalLink size={12} /> Retry Callback
                                 </button>

--- a/src/renderer/components/vault/VaultModals.tsx
+++ b/src/renderer/components/vault/VaultModals.tsx
@@ -50,10 +50,10 @@ export function VaultModals({
       {/* SEED MODAL */}
       {showSeed && (
         <div className="fixed top-0 bottom-0 right-0 left-[14rem] z-[100] flex items-center justify-center p-6 bg-xmr-base/90 backdrop-blur-md animate-in fade-in duration-300">
-          <div className="w-full max-w-lg bg-white text-black p-8 border-4 border-red-600 relative rounded-lg">
+          <div className="w-full max-w-lg bg-white text-black p-8 border-4 border-xmr-error relative rounded-lg">
             <button onClick={onCloseSeed} className="absolute top-4 right-4 cursor-pointer"><X size={24} /></button>
             <div className="space-y-6 font-black">
-              <div className="flex items-center gap-3 text-red-600 animate-pulse font-black"><ShieldAlert size={32} /><h3 className="text-2xl font-black uppercase tracking-tighter">Backup_Protocol</h3></div>
+              <div className="flex items-center gap-3 text-xmr-error animate-pulse font-black"><ShieldAlert size={32} /><h3 className="text-2xl font-black uppercase tracking-tighter">Backup_Protocol</h3></div>
               <div className="p-4 bg-black/5 border border-black/10 rounded-sm font-black text-sm leading-loose select-text text-black">{mnemonic}</div>
               <button onClick={onCloseSeed} className="w-full py-4 bg-black text-white font-black uppercase tracking-[0.2em] font-mono cursor-pointer">I_HAVE_SECURED_THE_KEY</button>
             </div>

--- a/src/renderer/components/vigil/VigilConfig.tsx
+++ b/src/renderer/components/vigil/VigilConfig.tsx
@@ -302,7 +302,7 @@ export function VigilConfig({ mode, setMode, data, setData, onArm, currentPrice 
           onClick={() => setMode('EJECT')}
           className={`relative overflow-hidden group px-3 py-2.5 border rounded-sm transition-all duration-300 flex items-center gap-3
             ${!isSnipe
-              ? 'bg-red-500/10 border-red-500/50 text-red-500 ring-1 ring-red-500/50'
+              ? 'bg-xmr-error/10 border-xmr-error/50 text-xmr-error ring-1 ring-xmr-error/50'
               : 'bg-xmr-base border-xmr-border text-xmr-dim hover:border-xmr-dim/50 hover:text-current'
             }`}
         >
@@ -313,7 +313,7 @@ export function VigilConfig({ mode, setMode, data, setData, onArm, currentPrice 
             <span className="block text-sm font-bold tracking-wider">EJECT</span>
             <span className="text-[9px] uppercase tracking-wider opacity-60">Auto-sell at target</span>
           </div>
-          {!isSnipe && <div className="absolute inset-0 bg-red-500/5 blur-xl" />}
+          {!isSnipe && <div className="absolute inset-0 bg-xmr-error/5 blur-xl" />}
         </button>
       </div>
 
@@ -358,12 +358,12 @@ export function VigilConfig({ mode, setMode, data, setData, onArm, currentPrice 
                 value={data.triggerPrice}
                 onChange={(e: any) => setData({ ...data, triggerPrice: e.target.value })}
                 className={`w-full bg-xmr-base border rounded py-2 px-3 pl-6 text-sm font-mono text-current focus:outline-none transition-colors
-                  ${mainStatus === 'immediate' ? 'border-yellow-500 text-yellow-500' : 'border-xmr-border focus:border-xmr-ghost'}
+                  ${mainStatus === 'immediate' ? 'border-xmr-warning text-xmr-warning' : 'border-xmr-border focus:border-xmr-ghost'}
                 `}
               />
             </div>
             {mainStatus === 'immediate' && (
-              <div className="text-[9px] text-yellow-500 animate-pulse font-mono uppercase">!! IMMEDIATE EXECUTION</div>
+              <div className="text-[9px] text-xmr-warning animate-pulse font-mono uppercase">!! IMMEDIATE EXECUTION</div>
             )}
           </div>
 
@@ -371,7 +371,7 @@ export function VigilConfig({ mode, setMode, data, setData, onArm, currentPrice 
           {useStop && (
             <div className="flex-1 space-y-1 animate-in fade-in slide-in-from-right-2">
               <label className="text-[10px] text-xmr-dim font-mono uppercase tracking-wider flex items-center gap-1.5">
-                <div className="w-1.5 h-1.5 rounded-full bg-red-500" />
+                <div className="w-1.5 h-1.5 rounded-full bg-xmr-error" />
                 {isSnipe ? 'STOP (BREAKOUT)' : 'STOP (LOSS)'}
               </label>
               <div className="relative">
@@ -382,12 +382,12 @@ export function VigilConfig({ mode, setMode, data, setData, onArm, currentPrice 
                   value={data.stopPrice}
                   onChange={(e: any) => setData({ ...data, stopPrice: e.target.value })}
                   className={`w-full bg-xmr-base border rounded py-2 px-3 pl-6 text-sm font-mono text-current focus:outline-none transition-colors
-                    ${stopStatus === 'immediate' ? 'border-yellow-500 text-yellow-500' : 'border-xmr-border focus:border-red-500/50'}
+                    ${stopStatus === 'immediate' ? 'border-xmr-warning text-xmr-warning' : 'border-xmr-border focus:border-xmr-error/50'}
                   `}
                 />
               </div>
               {stopStatus === 'immediate' && (
-                <div className="text-[9px] text-yellow-500 animate-pulse font-mono uppercase">!! IMMEDIATE EXECUTION</div>
+                <div className="text-[9px] text-xmr-warning animate-pulse font-mono uppercase">!! IMMEDIATE EXECUTION</div>
               )}
             </div>
           )}
@@ -463,7 +463,7 @@ export function VigilConfig({ mode, setMode, data, setData, onArm, currentPrice 
                 ) : isValid ? (
                   <><CheckCircle2 size={10} className="text-xmr-green" /> <span className="text-xmr-green font-bold">VALID</span></>
                 ) : (
-                  <><AlertCircle size={10} className="text-red-500" /> <span className="text-red-500 font-bold">INVALID</span></>
+                  <><AlertCircle size={10} className="text-xmr-error" /> <span className="text-xmr-error font-bold">INVALID</span></>
                 )}
               </div>
             )}
@@ -478,7 +478,7 @@ export function VigilConfig({ mode, setMode, data, setData, onArm, currentPrice 
             value={data.targetAddress}
             onChange={(e: any) => setData({ ...data, targetAddress: e.target.value })}
             className={`w-full bg-xmr-base border rounded py-2 px-3 font-mono text-xs text-current focus:outline-none transition-colors placeholder:text-xmr-dim/30
-              ${data.targetAddress && !isValid && !isValidating ? 'border-red-500/50 focus:border-red-500' : 'border-xmr-border focus:border-xmr-ghost'}
+              ${data.targetAddress && !isValid && !isValidating ? 'border-xmr-error/50 focus:border-xmr-error' : 'border-xmr-border focus:border-xmr-ghost'}
             `}
           />
           {data.outputCurrency?.memo && (

--- a/src/renderer/components/vigil/VigilDashboard.tsx
+++ b/src/renderer/components/vigil/VigilDashboard.tsx
@@ -82,8 +82,8 @@ export function VigilDashboard({
     switch (type) {
       case 'error': return 'text-xmr-error';
       case 'success': return 'text-xmr-green';
-      case 'warn': return 'text-yellow-500';
-      case 'trigger': return 'text-red-500 font-bold';
+      case 'warn': return 'text-xmr-warning';
+      case 'trigger': return 'text-xmr-error font-bold';
       default: return 'text-xmr-dim';
     }
   };
@@ -95,7 +95,7 @@ export function VigilDashboard({
       <div className="relative bg-xmr-base/50 border border-xmr-border/30 rounded-md p-6 overflow-hidden">
         {/* Background glow when triggered */}
         {isTriggered && (
-          <div className="absolute inset-0 bg-red-500/5 animate-pulse" />
+          <div className="absolute inset-0 bg-xmr-error/5 animate-pulse" />
         )}
 
         <div className="relative z-10">
@@ -106,15 +106,15 @@ export function VigilDashboard({
                 XMR / USD Market Price
               </div>
               <div className={`text-5xl font-black tracking-tighter tabular-nums transition-colors duration-300 drop-shadow-lg font-mono
-                ${isTriggered ? 'text-red-500 animate-pulse' : ''}
+                ${isTriggered ? 'text-xmr-error animate-pulse' : ''}
                 ${priceFlash === 'up' ? 'text-xmr-green' : ''}
-                ${priceFlash === 'down' ? 'text-red-400' : ''}
+                ${priceFlash === 'down' ? 'text-xmr-error' : ''}
                 ${!isTriggered && !priceFlash ? 'text-current' : ''}
               `}>
                 ${displayPrice.toFixed(2)}
               </div>
               {comparison && (
-                <div className={`text-[10px] font-mono mt-1 ${comparison.isClose ? 'text-yellow-500 animate-pulse' : 'text-xmr-dim'}`}>
+                <div className={`text-[10px] font-mono mt-1 ${comparison.isClose ? 'text-xmr-warning animate-pulse' : 'text-xmr-dim'}`}>
                   {comparison.diff > 0 ? '+' : ''}{comparison.diff.toFixed(2)}% FROM TARGET
                   {comparison.isClose && ' -- APPROACHING'}
                 </div>
@@ -125,7 +125,7 @@ export function VigilDashboard({
               <div className={`flex items-center gap-2 text-[10px] font-mono px-2 py-1 rounded border backdrop-blur-sm
                 ${priceConnected
                   ? 'text-xmr-green border-xmr-green/20 bg-xmr-green/5'
-                  : 'text-red-500 border-red-500/20 bg-red-500/5 animate-pulse'
+                  : 'text-xmr-error border-xmr-error/20 bg-xmr-error/5 animate-pulse'
                 }
               `}>
                 <Radio size={12} className={priceConnected ? 'animate-pulse' : ''} />
@@ -134,7 +134,7 @@ export function VigilDashboard({
 
               <div className={`text-[9px] font-mono uppercase tracking-widest px-2 py-1 rounded border
                 ${isTriggered
-                  ? 'text-red-500 border-red-500/30 bg-red-500/10 animate-pulse'
+                  ? 'text-xmr-error border-xmr-error/30 bg-xmr-error/10 animate-pulse'
                   : 'text-xmr-ghost border-xmr-ghost/20 bg-xmr-ghost/5'
                 }
               `}>
@@ -160,17 +160,17 @@ export function VigilDashboard({
             {/* Stop / Strategy */}
             <div className={`p-3 rounded border space-y-1
               ${hasStop
-                ? 'border-red-500/20 bg-red-500/5'
+                ? 'border-xmr-error/20 bg-xmr-error/5'
                 : 'border-xmr-border/20 bg-xmr-surface/30'
               }
             `}>
               {hasStop ? (
                 <>
                   <div className="text-[9px] text-xmr-dim font-mono uppercase tracking-widest flex items-center gap-1.5">
-                    <div className="w-1.5 h-1.5 rounded-full bg-red-500" />
+                    <div className="w-1.5 h-1.5 rounded-full bg-xmr-error" />
                     {mode === 'SNIPE' ? 'BREAKOUT STOP' : 'STOP LOSS'}
                   </div>
-                  <div className="text-xl font-black font-mono text-red-400 flex items-center gap-1.5">
+                  <div className="text-xl font-black font-mono text-xmr-error flex items-center gap-1.5">
                     <Shield size={14} />
                     ${stopVal.toFixed(2)}
                   </div>

--- a/src/renderer/contexts/VaultContext.tsx
+++ b/src/renderer/contexts/VaultContext.tsx
@@ -506,7 +506,7 @@ export function VaultProvider({ children }: { children: React.ReactNode }) {
       const address = await WalletService.createSubaddress(label || '', accountIndex || 0);
       await refresh();
       return address;
-    } catch (e) { console.error(e); }
+    } catch (e) { console.warn('[Vault] Subaddress creation failed:', e); }
   }, [refresh]);
 
   const purgeIdentity = useCallback(async (id: string) => {
@@ -567,7 +567,7 @@ export function VaultProvider({ children }: { children: React.ReactNode }) {
         const nextActiveId = current || (validIds.length > 0 ? validIds[0].id : '');
         setActiveId(nextActiveId);
         setHasVaultFile(validIds.length > 0 && !!nextActiveId);
-      } catch (err) { } finally {
+      } catch (err) { console.warn('[Vault] Failed to load identities:', err); } finally {
         setIsAppLoading(false);
       }
     };

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -20,8 +20,8 @@
   --radius-md: var(--skin-radius-md, 0.5rem);
   --radius-lg: var(--skin-radius-lg, 0.75rem);
   --radius-xl: var(--skin-radius-xl, 1rem);
-  --radius-2xl: var(--skin-radius-xl, 1rem);
-  --radius-3xl: var(--skin-radius-xl, 1.5rem);
+  --radius-2xl: var(--skin-radius-2xl, 1rem);
+  --radius-3xl: var(--skin-radius-3xl, 1.5rem);
 }
 
 :root {
@@ -36,6 +36,8 @@
   --skin-radius-md: 4px;
   --skin-radius-lg: 6px;
   --skin-radius-xl: 8px;
+  --skin-radius-2xl: 12px;
+  --skin-radius-3xl: 16px;
 }
 
 .dark {
@@ -106,6 +108,8 @@
   --skin-radius-md: 4px;
   --skin-radius-lg: 6px;
   --skin-radius-xl: 8px;
+  --skin-radius-2xl: 12px;
+  --skin-radius-3xl: 16px;
 }
 
 .skin-clean {
@@ -113,6 +117,8 @@
   --skin-radius-md: 10px;
   --skin-radius-lg: 14px;
   --skin-radius-xl: 20px;
+  --skin-radius-2xl: 24px;
+  --skin-radius-3xl: 28px;
 }
 
 .skin-monero {
@@ -120,6 +126,8 @@
   --skin-radius-md: 8px;
   --skin-radius-lg: 10px;
   --skin-radius-xl: 14px;
+  --skin-radius-2xl: 18px;
+  --skin-radius-3xl: 22px;
 }
 
 /* ─── SKIN: Clean (Professional / Financial) ─── */

--- a/src/renderer/services/swap.ts
+++ b/src/renderer/services/swap.ts
@@ -469,7 +469,8 @@ export const fetchBridgeEstimate = async (from: string, to: string, amount: numb
       try {
         const errData = await res.json();
         if (errData.error) errMsg = errData.error;
-      } catch {
+      } catch (e) {
+        console.warn('[Swap] Error body parse failed:', e);
         errMsg = await res.text() || res.statusText;
       }
       throw new Error(errMsg.split('error":')?.[1]?.replaceAll(/["\\}]/g, '') || errMsg);
@@ -633,7 +634,8 @@ export async function fetchBridgeStatusV2(id: string, engine?: string): Promise<
     try {
       const trade2 = await apiClient<BridgeTradeV2>(`/v2/exchange/status/${secondId}${params}`);
       return [trade1, trade2];
-    } catch {
+    } catch (e) {
+      console.warn('[Swap] Second leg status fetch failed:', e);
       return [trade1];
     }
   }


### PR DESCRIPTION
## Summary

- Replace ~80 hardcoded Tailwind color classes (`text-red-500`, `bg-red-500`, `text-yellow-500`, `text-orange-500`, etc.) with theme-aware `xmr-error`, `xmr-warning`, and `xmr-accent` variables across 20 components
- This ensures error, warning, and accent states render correctly across all skin/theme combinations (terminal, clean, monero) in both light and dark modes
- Replace ~15 silent/empty catch blocks with `console.warn` logging so errors are discoverable during debugging without breaking UX

### Files changed (24)
**Theme color normalization:** VigilView, VigilDashboard, VigilConfig, ExchangeView, SettingsView, HomeView, AuthForm, IdentitySwitcher, XMR402Modal, CurrencyInput, SpreadChart, DirectSendTab, GhostSendTab, TransactionLedger, DispatchPasswordGate, ChurnModal, SplinterModal, VaultModals, AddressBook, AddressList

**Silent catch fixes:** App.tsx, ExchangeView, VaultContext, SyncWatcher, GhostSendTab, DirectSendTab, swap.ts

## Test plan
- [ ] Verify dark mode terminal skin renders error/warning states correctly
- [ ] Verify light mode renders error/warning states correctly
- [ ] Verify clean and monero skins render error/warning states correctly
- [ ] Test Vigil view in all states (IDLE, WATCHING, TRIGGERED, ERROR)
- [ ] Test exchange flow (swap + ghost modes)
- [ ] Test send flow (direct + ghost) with invalid addresses
- [ ] Verify Settings danger zone styling

🤖 Generated with [Claude Code](https://claude.com/claude-code)