### PR TITLE
refactor: standardize UI border radius and clean up imports

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -369,7 +369,7 @@ function MainApp() {
         {/* ─── Portfolio Card ─── */}
         {vault.accounts.length > 0 && (
           <div
-            className="mx-3 mt-1 p-3 bg-gradient-to-br from-xmr-green/10 to-transparent border border-xmr-border/30 rounded-lg cursor-pointer hover:border-xmr-green/30 transition-all"
+            className="mx-3 mt-1 p-3 bg-gradient-to-br from-xmr-green/10 to-transparent border border-xmr-border/30 rounded-sm cursor-pointer hover:border-xmr-green/30 transition-all"
             style={{ WebkitAppRegion: 'no-drag' } as any}
             onClick={() => setView('vault')}
           >

--- a/src/renderer/components/AuthView.tsx
+++ b/src/renderer/components/AuthView.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect, type FormEvent } from 'react';
 import { Shield, ShieldCheck, Users, Globe, ShieldAlert } from 'lucide-react';
 import { Card } from './Card';
 import { AuthForm } from './auth/AuthForm';
@@ -92,7 +92,7 @@ export function AuthView({ onUnlock, isInitialSetup, identities, activeId, onSwi
     onSwitchIdentity(id);
   };
 
-  const handleUnlockSubmit = async (e: React.FormEvent) => {
+  const handleUnlockSubmit = async (e: FormEvent) => {
     e.preventDefault();
     if (isProcessing) return;
 
@@ -159,7 +159,7 @@ export function AuthView({ onUnlock, isInitialSetup, identities, activeId, onSwi
             seedLanguage={seedLanguage} setSeedLanguage={setSeedLanguage}
             error={error} isProcessing={isProcessing} logs={logs}
             handleUnlockSubmit={handleUnlockSubmit}
-            handleCreateFinalize={() => { }}
+
           />
 
           {!isProcessing && step === 'AUTH' && (
@@ -186,7 +186,7 @@ export function AuthView({ onUnlock, isInitialSetup, identities, activeId, onSwi
                 <button
                   type="button"
                   onClick={toggleNetwork}
-                  className={`px-2 py-0.5 rounded border text-xs font-black transition-all cursor-pointer ${routingMode === 'tor'
+                  className={`px-2 py-0.5 rounded-sm border text-xs font-black transition-all cursor-pointer ${routingMode === 'tor'
                     ? 'border-xmr-green/50 text-xmr-green hover:bg-xmr-green/10'
                     : 'border-xmr-accent/50 text-xmr-accent hover:bg-xmr-accent/10'
                     }`}

--- a/src/renderer/components/Card.tsx
+++ b/src/renderer/components/Card.tsx
@@ -29,7 +29,7 @@ export function Card({
 
   return (
     <div className={`
-      bg-xmr-surface border shadow-lg relative overflow-hidden group rounded-md
+      bg-xmr-surface border shadow-lg relative overflow-hidden group rounded-sm
       ${borderClass}
       ${noPadding ? '' : 'p-6'}
       ${className}

--- a/src/renderer/components/ComplianceSelector.tsx
+++ b/src/renderer/components/ComplianceSelector.tsx
@@ -103,7 +103,7 @@ export function ComplianceSelector({
 
         <div className="flex items-center gap-2 md:gap-3 shrink-0">
            {/* Summary Badge */}
-           <div className={`flex items-center gap-1.5 px-2 py-1 rounded border text-[11px] font-mono font-bold whitespace-nowrap ${summary.color} ${summary.bg}`}>
+           <div className={`flex items-center gap-1.5 px-2 py-1 rounded-sm border text-[11px] font-mono font-bold whitespace-nowrap ${summary.color} ${summary.bg}`}>
               {summary.label === 'MAX PRIVACY' && <Lock size={10} className="shrink-0" />}
               {summary.label === 'BEST RATE (RISK)' && <Zap size={10} className="shrink-0" />}
               {summary.label === 'BALANCED' && <ShieldCheck size={10} className="shrink-0" />}

--- a/src/renderer/components/CurrencyInput.tsx
+++ b/src/renderer/components/CurrencyInput.tsx
@@ -158,7 +158,7 @@ export function CurrencyInput({
     <div className="fixed inset-0 z-[100] flex items-center justify-center bg-xmr-base/90 backdrop-blur-md animate-in fade-in duration-200 p-4">
       <div className="absolute inset-0" onClick={() => setIsModalOpen(false)}></div>
 
-      <div className="relative w-full max-w-sm bg-xmr-base border border-xmr-green/50 shadow-[0_0_50px_rgba(0,255,65,0.1)] rounded-lg overflow-hidden flex flex-col max-h-[70vh] animate-in zoom-in-95 duration-200 z-10">
+      <div className="relative w-full max-w-sm bg-xmr-base border border-xmr-green/50 shadow-[0_0_50px_rgba(0,255,65,0.1)] rounded-sm overflow-hidden flex flex-col max-h-[70vh] animate-in zoom-in-95 duration-200 z-10">
         {/* Header */}
         <div className="p-4 border-b border-xmr-border flex justify-between items-center bg-xmr-surface">
           <h3 className="font-bold text-xmr-green tracking-[0.2em] text-sm flex items-center gap-2">
@@ -219,7 +219,7 @@ export function CurrencyInput({
         </div>
 
         {/* Footer Status */}
-        <div className="p-2 border-t border-xmr-border bg-xmr-surface text-xs text-xmr-dim flex justify-between rounded-b-lg font-mono">
+        <div className="p-2 border-t border-xmr-border bg-xmr-surface text-xs text-xmr-dim flex justify-between rounded-b-sm font-mono">
           <span>STATUS: {isListReady ? 'ONLINE' : 'SYNCING'}</span>
           <span>{tokenList.length} ASSETS</span>
         </div>

--- a/src/renderer/components/CurrencyInput.tsx
+++ b/src/renderer/components/CurrencyInput.tsx
@@ -29,7 +29,7 @@ const TokenRow = ({ token, isActive, onClick }: { token: Currency, isActive: boo
   <button
     onClick={onClick}
     className={`
-          w-full flex items-center justify-between p-3 rounded cursor-pointer transition-all border content-visibility-auto
+          w-full flex items-center justify-between p-3 rounded-sm cursor-pointer transition-all border content-visibility-auto
           ${['testnet', 'stagenet', 'sepolia'].includes(token?.network.toLowerCase() || '') ? 'border-xmr-warning text-xmr-surface' : ''}
           ${isActive
         ? 'bg-xmr-green/10 border-xmr-green/30'
@@ -46,7 +46,7 @@ const TokenRow = ({ token, isActive, onClick }: { token: Currency, isActive: boo
         </div>
         <div className="text-xs text-xmr-dim/70 uppercase font-bold tracking-wider flex items-center gap-2">
           {token.name}
-          <span className="bg-xmr-surface border border-xmr-border px-1 rounded opacity-80">{token.network}</span>
+          <span className="bg-xmr-surface border border-xmr-border px-1 rounded-sm opacity-80">{token.network}</span>
         </div>
       </div>
     </div>
@@ -177,7 +177,7 @@ export function CurrencyInput({
             value={searchTerm}
             onChange={(e) => setSearchTerm(e.target.value)}
             placeholder="SEARCH (Ticker, Name)..."
-            className="w-full bg-xmr-surface border border-xmr-border rounded px-3 py-2 text-sm text-xmr-dim focus:border-xmr-green outline-none placeholder-xmr-dim/50 uppercase"
+            className="w-full bg-xmr-surface border border-xmr-border rounded-sm px-3 py-2 text-sm text-xmr-dim focus:border-xmr-green outline-none placeholder-xmr-dim/50 uppercase"
           />
         </div>
 
@@ -210,7 +210,7 @@ export function CurrencyInput({
               )}
 
               {displayList.length === 0 && (
-                <div className="p-8 text-center text-xmr-dim text-xs border border-dashed border-xmr-dim/20 rounded m-2">
+                <div className="p-8 text-center text-xmr-dim text-xs border border-dashed border-xmr-dim/20 rounded-sm m-2">
                   NO_ASSETS_FOUND
                 </div>
               )}

--- a/src/renderer/components/CurrencySelector.tsx
+++ b/src/renderer/components/CurrencySelector.tsx
@@ -386,7 +386,7 @@ export function CurrencySelector({
             position ? (
               <div
                 ref={portalRef}
-                className={`fixed z-[100] rounded-md shadow-2xl flex flex-col max-h-[48vh] md:max-h-[40vh] animate-in fade-in zoom-in-95 duration-100
+                className={`fixed z-[100] rounded-sm shadow-2xl flex flex-col max-h-[48vh] md:max-h-[40vh] animate-in fade-in zoom-in-95 duration-100
                    ${forceDark ? 'dark' : ''}
                    bg-[var(--color-xmr-surface)] border border-[var(--local-border)]
                 `}

--- a/src/renderer/components/CurrencySelector.tsx
+++ b/src/renderer/components/CurrencySelector.tsx
@@ -66,7 +66,7 @@ function CurrencyList({ loading, displayList, filteredCount, selected, onSelect 
                 </div>
                 <div className="text-xs text-[var(--local-text-dim)] flex items-center gap-2">
                   {c.name}
-                  <span className="bg-[var(--color-xmr-surface)] border border-[var(--local-border)] px-1 rounded text-[var(--local-text-dim)]/80">
+                  <span className="bg-[var(--color-xmr-surface)] border border-[var(--local-border)] px-1 rounded-sm text-[var(--local-text-dim)]/80">
                     {c.network}
                   </span>
                 </div>
@@ -274,7 +274,7 @@ export function CurrencySelector({
           type="button"
           onClick={() => setIsOpen(!isOpen)}
 
-          className={`w-full flex items-center justify-between px-2 md:px-4 py-2.5 rounded transition-all duration-200 ${hideBorder ? 'border-0' : 'border'}
+          className={`w-full flex items-center justify-between px-2 md:px-4 py-2.5 rounded-sm transition-all duration-200 ${hideBorder ? 'border-0' : 'border'}
             ${bg} text-[var(--local-text-dim)] 
             ${isOpen
               ? "ring-1 ring-[var(--local-brand)]/50 border-[var(--local-brand)] text-[var(--local-brand)]"
@@ -398,7 +398,7 @@ export function CurrencySelector({
                 }}
               >
                 {/* Search Input */}
-                <div className="p-3 border-b border-[var(--local-border)] sticky top-0 bg-[var(--color-xmr-surface)] z-10 rounded-t-md">
+                <div className="p-3 border-b border-[var(--local-border)] sticky top-0 bg-[var(--color-xmr-surface)] z-10 rounded-t-sm">
                   <div className="relative">
                     <Search size={16} className="absolute left-3 top-1/2 -translate-y-1/2 text-[var(--local-text-dim)]" />
                     <input
@@ -425,7 +425,7 @@ export function CurrencySelector({
 
                 {/* Footer Status */}
                 {!loading && (
-                  <div className="p-2 border-t border-[var(--local-border)] bg-[var(--color-xmr-surface)] text-xs text-[var(--local-text-dim)] flex justify-between rounded-b-md font-mono">
+                  <div className="p-2 border-t border-[var(--local-border)] bg-[var(--color-xmr-surface)] text-xs text-[var(--local-text-dim)] flex justify-between rounded-b-sm font-mono">
                     <span>STATUS: ONLINE</span>
                     <span>{includedCurrencies.length} ASSETS</span>
                   </div>

--- a/src/renderer/components/ExchangeView.tsx
+++ b/src/renderer/components/ExchangeView.tsx
@@ -358,7 +358,7 @@ export function ExchangeView({ localXmrAddress }: ExchangeViewProps) {
 
   // ─── Mode tab ───
   const ModeTab = () => (
-    <div className="flex items-center gap-1.5 bg-xmr-base border border-xmr-border/30 rounded-md p-1">
+    <div className="flex items-center gap-1.5 bg-xmr-base border border-xmr-border/30 rounded-sm p-1">
       {([
         { id: 'swap' as const, label: 'Swap', icon: Zap },
         { id: 'ghost' as const, label: 'Ghost', icon: Ghost },
@@ -433,7 +433,7 @@ export function ExchangeView({ localXmrAddress }: ExchangeViewProps) {
             return (
               <button
                 key={`${route.engine || route.provider}-${route.fixed ? 'f' : 'v'}-${i}`}
-                className={`w-full text-left cursor-pointer transition-all border rounded-md p-3 relative ${isSelected
+                className={`w-full text-left cursor-pointer transition-all border rounded-sm p-3 relative ${isSelected
                   ? isGhost
                     ? 'border-xmr-ghost bg-xmr-ghost/5 shadow-[0_0_12px_rgba(168,85,247,0.1)]'
                     : 'border-xmr-accent bg-xmr-accent/5 shadow-[0_0_12px_rgba(255,102,0,0.1)]'
@@ -521,7 +521,7 @@ export function ExchangeView({ localXmrAddress }: ExchangeViewProps) {
 
   // ─── Log Console (shared) ───
   const LogConsole = ({ label }: { label: string }) => (
-    <div className="bg-xmr-base border border-xmr-border/20 rounded-md overflow-hidden">
+    <div className="bg-xmr-base border border-xmr-border/20 rounded-sm overflow-hidden">
       <div className="flex items-center justify-between px-3 py-1.5 border-b border-xmr-border/20 bg-xmr-surface/30">
         <div className="flex items-center gap-2">
           <span className="relative flex h-1.5 w-1.5">
@@ -574,7 +574,7 @@ export function ExchangeView({ localXmrAddress }: ExchangeViewProps) {
                 </div>
               )}
             </Card>
-            <button onClick={handleReset} className="px-8 py-3 border border-xmr-ghost/50 text-xmr-ghost text-[10px] font-black uppercase tracking-[0.2em] hover:bg-xmr-ghost/10 transition-all cursor-pointer rounded-md">NEW_EXCHANGE</button>
+            <button onClick={handleReset} className="px-8 py-3 border border-xmr-ghost/50 text-xmr-ghost text-[10px] font-black uppercase tracking-[0.2em] hover:bg-xmr-ghost/10 transition-all cursor-pointer rounded-sm">NEW_EXCHANGE</button>
           </div>
         </div>
       );
@@ -602,7 +602,7 @@ export function ExchangeView({ localXmrAddress }: ExchangeViewProps) {
               )}
             </Card>
           )}
-          <button onClick={handleReset} className="px-8 py-3 border border-xmr-green/50 text-xmr-green text-[10px] font-black uppercase tracking-[0.2em] hover:bg-xmr-green/10 transition-all cursor-pointer rounded-md">NEW_EXCHANGE</button>
+          <button onClick={handleReset} className="px-8 py-3 border border-xmr-green/50 text-xmr-green text-[10px] font-black uppercase tracking-[0.2em] hover:bg-xmr-green/10 transition-all cursor-pointer rounded-sm">NEW_EXCHANGE</button>
         </div>
       </div>
     );
@@ -664,7 +664,7 @@ export function ExchangeView({ localXmrAddress }: ExchangeViewProps) {
                 <div className="text-[10px] text-xmr-ghost font-mono uppercase tracking-widest font-bold">Deposit_Required</div>
                 <p className="text-[9px] text-xmr-dim">Send the amount below to initiate the ghost sequence</p>
               </div>
-              <div className="p-4 bg-xmr-base border border-xmr-ghost/20 rounded-md space-y-3">
+              <div className="p-4 bg-xmr-base border border-xmr-ghost/20 rounded-sm space-y-3">
                 <div className="flex justify-between text-[10px] font-bold uppercase font-mono"><span className="text-xmr-dim">Amount</span><span className="text-xmr-ghost">{leg1.depositAmount} {leg1.fromTicker}</span></div>
                 <div className="flex items-center gap-2">
                   <AddressDisplay address={leg1.depositAddress} className="text-[10px] text-xmr-green font-bold flex-grow" />
@@ -675,7 +675,7 @@ export function ExchangeView({ localXmrAddress }: ExchangeViewProps) {
           )}
 
           {/* Summary */}
-          <div className="flex items-center gap-4 justify-between text-xs font-bold uppercase tracking-tighter p-4 bg-xmr-surface/50 border border-xmr-border/20 rounded-md">
+          <div className="flex items-center gap-4 justify-between text-xs font-bold uppercase tracking-tighter p-4 bg-xmr-surface/50 border border-xmr-border/20 rounded-sm">
             <div className="flex flex-col gap-1"><span className="text-xmr-dim text-[9px]">You_Send</span><span className="text-xmr-green">{leg1.fromAmount || leg1.depositAmount} {leg1.fromTicker}</span></div>
             <div className="flex items-center gap-1 text-xmr-ghost"><ArrowRight size={10} /><Ghost size={12} /><ArrowRight size={10} /></div>
             <div className="flex flex-col gap-1 text-right"><span className="text-xmr-dim text-[9px]">You_Receive</span><span className="text-xmr-green">{(leg2 || leg1).toAmount} {(leg2 || leg1).toTicker}</span></div>
@@ -691,7 +691,7 @@ export function ExchangeView({ localXmrAddress }: ExchangeViewProps) {
           )}
 
           <LogConsole label="GHOST_LOG" />
-          <button onClick={handleReset} className="w-full py-3 bg-xmr-error/5 hover:bg-xmr-error/10 border border-xmr-error/20 text-xmr-error text-[10px] font-bold uppercase tracking-[0.2em] flex items-center justify-center gap-2 transition-all cursor-pointer rounded-md"><X size={14} /> Abort_Session</button>
+          <button onClick={handleReset} className="w-full py-3 bg-xmr-error/5 hover:bg-xmr-error/10 border border-xmr-error/20 text-xmr-error text-[10px] font-bold uppercase tracking-[0.2em] flex items-center justify-center gap-2 transition-all cursor-pointer rounded-sm"><X size={14} /> Abort_Session</button>
         </div>
       );
     }
@@ -736,7 +736,7 @@ export function ExchangeView({ localXmrAddress }: ExchangeViewProps) {
                   <p className="text-[9px] text-xmr-dim">Send the exact amount to the address below</p>
                 )}
               </div>
-              <div className="p-4 bg-xmr-base border border-xmr-accent/20 rounded-md space-y-3">
+              <div className="p-4 bg-xmr-base border border-xmr-accent/20 rounded-sm space-y-3">
                 <div className="flex justify-between text-[10px] font-bold uppercase font-mono"><span className="text-xmr-dim">{isFloating ? 'Suggested Amount' : 'Amount'}</span><span className="text-xmr-accent">{depositAmt} {(activeTrade.ticker_from || fromCoin.ticker).toUpperCase()}</span></div>
                 <div className="flex items-center gap-2">
                   <AddressDisplay address={depositAddr} className="text-[10px] text-xmr-green font-bold flex-grow" />
@@ -746,7 +746,7 @@ export function ExchangeView({ localXmrAddress }: ExchangeViewProps) {
             </Card>
           )}
 
-          <div className="flex items-center gap-4 justify-between text-xs font-bold uppercase tracking-tighter p-4 bg-xmr-surface/50 border border-xmr-border/20 rounded-md">
+          <div className="flex items-center gap-4 justify-between text-xs font-bold uppercase tracking-tighter p-4 bg-xmr-surface/50 border border-xmr-border/20 rounded-sm">
             <div className="flex flex-col gap-1"><span className="text-xmr-dim text-[9px]">You_Send</span><span className="text-xmr-green">{activeTrade.amount_from} {(activeTrade.ticker_from || '').toUpperCase()}</span></div>
             <ArrowRight size={16} className="text-xmr-dim" />
             <div className="flex flex-col gap-1 text-right"><span className="text-xmr-dim text-[9px]">You_Receive</span><span className="text-xmr-green">{activeTrade.amount_to} {(activeTrade.ticker_to || '').toUpperCase()}</span></div>
@@ -760,7 +760,7 @@ export function ExchangeView({ localXmrAddress }: ExchangeViewProps) {
           )}
 
           <LogConsole label="SWAP_LOG" />
-          <button onClick={handleReset} className="w-full py-3 bg-xmr-error/5 hover:bg-xmr-error/10 border border-xmr-error/20 text-xmr-error text-[10px] font-bold uppercase tracking-[0.2em] flex items-center justify-center gap-2 transition-all cursor-pointer rounded-md"><X size={14} /> Cancel_Trade</button>
+          <button onClick={handleReset} className="w-full py-3 bg-xmr-error/5 hover:bg-xmr-error/10 border border-xmr-error/20 text-xmr-error text-[10px] font-bold uppercase tracking-[0.2em] flex items-center justify-center gap-2 transition-all cursor-pointer rounded-sm"><X size={14} /> Cancel_Trade</button>
         </div>
       );
     }
@@ -785,7 +785,7 @@ export function ExchangeView({ localXmrAddress }: ExchangeViewProps) {
         topGradientAccentColor={isGhost ? 'xmr-ghost' : 'xmr-accent'}
       >
         {/* Source */}
-        <div className={`flex gap-2 items-center bg-xmr-base border border-xmr-border/30 px-2 rounded-md h-14 transition-colors ${isGhost ? 'focus-within:border-xmr-ghost/50' : 'focus-within:border-xmr-accent/50'}`}>
+        <div className={`flex gap-2 items-center bg-xmr-base border border-xmr-border/30 px-2 rounded-sm h-14 transition-colors ${isGhost ? 'focus-within:border-xmr-ghost/50' : 'focus-within:border-xmr-accent/50'}`}>
           <div className="w-[45%] shrink-0">
             <CurrencySelector label="" selected={fromCoin} onSelect={setFromCoin} currencies={currencies} hideBorder themeColor={isGhost ? 'xmr-ghost' : undefined} variant="drawer" drawerTitle="Source Asset" />
           </div>
@@ -810,7 +810,7 @@ export function ExchangeView({ localXmrAddress }: ExchangeViewProps) {
         </div>
 
         {/* Target */}
-        <div className="flex gap-2 items-center bg-xmr-base border border-xmr-border/30 px-2 rounded-md h-14">
+        <div className="flex gap-2 items-center bg-xmr-base border border-xmr-border/30 px-2 rounded-sm h-14">
           <div className="w-[45%] shrink-0">
             <CurrencySelector label="" selected={toCoin} onSelect={setToCoin} currencies={currencies} hideBorder themeColor={isGhost ? 'xmr-ghost' : undefined} variant="drawer" drawerTitle="Target Asset" />
           </div>
@@ -828,7 +828,7 @@ export function ExchangeView({ localXmrAddress }: ExchangeViewProps) {
         {/* Route selector button */}
         <button
           onClick={() => setRouteDrawerOpen(true)}
-          className={`w-full flex items-center justify-between px-3 py-2 bg-xmr-base border border-xmr-border/30 rounded-md transition-colors cursor-pointer group ${isGhost ? 'hover:border-xmr-ghost/40' : 'hover:border-xmr-accent/40'}`}
+          className={`w-full flex items-center justify-between px-3 py-2 bg-xmr-base border border-xmr-border/30 rounded-sm transition-colors cursor-pointer group ${isGhost ? 'hover:border-xmr-ghost/40' : 'hover:border-xmr-accent/40'}`}
         >
           <div className="flex items-center gap-2">
             <Radio size={11} className={`text-${themeColor}`} />
@@ -862,7 +862,7 @@ export function ExchangeView({ localXmrAddress }: ExchangeViewProps) {
             value={destAddress}
             onChange={e => setDestAddress(e.target.value)}
             placeholder="Destination address..."
-            className={`w-full bg-xmr-base border border-xmr-border/30 p-2.5 rounded-md text-xs text-xmr-green font-bold focus:outline-none transition-colors ${isGhost ? 'focus:border-xmr-ghost/50' : 'focus:border-xmr-accent/50'}`}
+            className={`w-full bg-xmr-base border border-xmr-border/30 p-2.5 rounded-sm text-xs text-xmr-green font-bold focus:outline-none transition-colors ${isGhost ? 'focus:border-xmr-ghost/50' : 'focus:border-xmr-accent/50'}`}
           />
         </div>
 
@@ -871,7 +871,7 @@ export function ExchangeView({ localXmrAddress }: ExchangeViewProps) {
           <div className="space-y-1">
             <label className="text-[9px] font-black text-xmr-dim uppercase ml-1">Memo / Tag</label>
             <input type="text" value={memo} onChange={e => setMemo(e.target.value)} placeholder="Required for this coin..."
-              className="w-full bg-xmr-base border border-xmr-border/30 p-2.5 rounded-md text-xs text-xmr-green font-bold focus:outline-none focus:border-xmr-accent/50 transition-colors" />
+              className="w-full bg-xmr-base border border-xmr-border/30 p-2.5 rounded-sm text-xs text-xmr-green font-bold focus:outline-none focus:border-xmr-accent/50 transition-colors" />
           </div>
         )}
 
@@ -881,7 +881,7 @@ export function ExchangeView({ localXmrAddress }: ExchangeViewProps) {
             <label className="text-[9px] font-black text-xmr-dim uppercase ml-1">Refund_Address</label>
             <input type="text" value={refundAddress} onChange={e => setRefundAddress(e.target.value)}
               placeholder={`${fromCoin?.ticker.toUpperCase() || ''} refund address...`}
-              className="w-full bg-xmr-base border border-xmr-border/30 p-2.5 rounded-md text-xs text-xmr-green font-bold focus:outline-none focus:border-xmr-ghost/50 transition-colors" />
+              className="w-full bg-xmr-base border border-xmr-border/30 p-2.5 rounded-sm text-xs text-xmr-green font-bold focus:outline-none focus:border-xmr-ghost/50 transition-colors" />
           </div>
         )}
 
@@ -892,7 +892,7 @@ export function ExchangeView({ localXmrAddress }: ExchangeViewProps) {
         <button
           disabled={!selectedRoute || !destAddress || isCreating || (isGhost && (selectedRoute as BridgeRoute)?.requiresRefund && !refundAddress)}
           onClick={handleExecute}
-          className={`w-full py-3 font-black uppercase tracking-[0.2em] text-sm rounded-md transition-all flex items-center justify-center gap-3 disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer active:scale-[0.98] shadow-lg ${
+          className={`w-full py-3 font-black uppercase tracking-[0.2em] text-sm rounded-sm transition-all flex items-center justify-center gap-3 disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer active:scale-[0.98] shadow-lg ${
             isGhost
               ? 'bg-xmr-ghost text-white hover:brightness-110 shadow-xmr-ghost/10'
               : 'bg-xmr-accent text-xmr-base hover:bg-xmr-green hover:text-xmr-base shadow-xmr-accent/10'

--- a/src/renderer/components/ExchangeView.tsx
+++ b/src/renderer/components/ExchangeView.tsx
@@ -441,7 +441,7 @@ export function ExchangeView({ localXmrAddress }: ExchangeViewProps) {
                 }`}
                 onClick={() => { setSelectedRoute(route); setRouteDrawerOpen(false); }}
               >
-                {isSelected && <div className={`absolute left-0 top-0 bottom-0 w-0.5 bg-${themeColor} rounded-l`} />}
+                {isSelected && <div className={`absolute left-0 top-0 bottom-0 w-0.5 bg-${themeColor} rounded-l-sm`} />}
                 <div className="flex items-center justify-between mb-1.5">
                   <div className="flex items-center gap-2">
                     {route.providerLogo && (

--- a/src/renderer/components/ExchangeView.tsx
+++ b/src/renderer/components/ExchangeView.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import React, { useState, useEffect, useRef, useMemo } from 'react';
+import { useState, useEffect, useRef, useMemo, Fragment } from 'react';
 import { Ghost, ArrowDown, ArrowRight, ArrowUpDown, Zap, Shield, RefreshCw, AlertCircle, Copy, Check, X, Radio, CheckCircle2, Loader2, ChevronRight, Clock, Server } from 'lucide-react';
 import { CurrencySelector } from './CurrencySelector';
 import { Card } from './Card';
@@ -471,10 +471,10 @@ export function ExchangeView({ localXmrAddress }: ExchangeViewProps) {
                 {isGhost && route.hops?.length > 0 && (
                   <div className="flex items-center gap-1 mt-1.5 text-[8px] text-xmr-dim">
                     {route.hops.map((hop: any, hi: number) => (
-                      <React.Fragment key={hi}>
+                      <Fragment key={hi}>
                         {hi > 0 && <ChevronRight size={7} className="text-xmr-border" />}
                         <span className="px-1 py-0.5 bg-xmr-base border border-xmr-border/20 uppercase">{hop.name}</span>
-                      </React.Fragment>
+                      </Fragment>
                     ))}
                   </div>
                 )}

--- a/src/renderer/components/HomeView.tsx
+++ b/src/renderer/components/HomeView.tsx
@@ -1,5 +1,5 @@
 import React, { Suspense } from 'react';
-import { Activity, BarChart3, Shield, Zap, Globe, Lock, Ghost, TrendingUp, AlertTriangle } from 'lucide-react';
+import { Activity, BarChart3, Globe, Lock, Ghost, TrendingUp, AlertTriangle } from 'lucide-react';
 import { useTheme } from '../hooks/useTheme';
 import { Card } from './Card';
 

--- a/src/renderer/components/SettingsView.tsx
+++ b/src/renderer/components/SettingsView.tsx
@@ -538,7 +538,7 @@ export function SettingsView() {
                     </div>
                   </div>
 
-                  <div className="border border-xmr-border/30 rounded overflow-hidden relative bg-black/50 h-24 flex items-center justify-center">
+                  <div className="border border-xmr-border/30 rounded-sm overflow-hidden relative bg-black/50 h-24 flex items-center justify-center">
                     <div
                       className="absolute inset-0 z-0 pointer-events-none"
                       style={{

--- a/src/renderer/components/SettingsView.tsx
+++ b/src/renderer/components/SettingsView.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import { Settings, Server, Zap, EyeOff, Check, RefreshCw, History, ShieldAlert, Edit2, Download, FolderOpen, ExternalLink, Loader2, Image as ImageIcon, Trash2, X } from 'lucide-react';
 import { Card } from './Card';
 import { useVault } from '../hooks/useVault';
@@ -29,7 +29,7 @@ export function SettingsView() {
 
   const [saveStatus, setSaveStatus] = useState<'idle' | 'saving' | 'saved'>('idle');
   const [targetHeight, setTargetHeight] = useState<string>('');
-  const [isRescanning, setIsRescaning] = useState(false);
+  const [isRescanning, setIsRescanning] = useState(false);
 
   // 📦 App Info & Updates state
   const [appInfo, setAppInfo] = useState<{ version: string; appDataPath: string; walletsPath: string; platform: string } | null>(null);
@@ -168,14 +168,14 @@ export function SettingsView() {
     if (isNaN(h)) return alert("INVALID_HEIGHT");
 
     if (confirm(`INITIATE_RESCAN from height ${h}? This will clear local wallet cache.`)) {
-      setIsRescaning(true);
+      setIsRescanning(true);
       try {
         await rescan(h);
         alert("RESCAN_SIGNAL_BROADCASTED.");
       } catch (e: any) {
         alert(`RESCAN_FAILED: ${e.message}`);
       } finally {
-        setIsRescaning(false);
+        setIsRescanning(false);
       }
     }
   };

--- a/src/renderer/components/SettingsView.tsx
+++ b/src/renderer/components/SettingsView.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { Settings, Server, Zap, EyeOff, Check, RefreshCw, History, ShieldAlert, Edit2, Download, FolderOpen, ExternalLink, Info, Loader2, Image as ImageIcon, Trash2, X } from 'lucide-react';
+import { Settings, Server, Zap, EyeOff, Check, RefreshCw, History, ShieldAlert, Edit2, Download, FolderOpen, ExternalLink, Loader2, Image as ImageIcon, Trash2, X } from 'lucide-react';
 import { Card } from './Card';
 import { useVault } from '../hooks/useVault';
 

--- a/src/renderer/components/SpreadChart.tsx
+++ b/src/renderer/components/SpreadChart.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { useEffect, useRef, useState } from 'react';
 import { useTheme } from '../hooks/useTheme';

--- a/src/renderer/components/VaultView.tsx
+++ b/src/renderer/components/VaultView.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { RefreshCw, Key, Send, Download, Wind, Loader2, Edit2, Scissors, MoreVertical, Plus, ChevronLeft, ChevronRight } from 'lucide-react';
 import { AddressBook } from './vault/AddressBook';
 import { AddressList } from './vault/AddressList';

--- a/src/renderer/components/VaultView.tsx
+++ b/src/renderer/components/VaultView.tsx
@@ -191,16 +191,16 @@ export function VaultView({ setView, vault, handleBurn, appConfig }: VaultViewPr
         <div className="relative" style={{ perspective: '800px' }}>
           {/* Background cards (stack effect) */}
           {accounts.length >= 3 && (
-            <div className="absolute top-0 left-8 right-8 h-full bg-xmr-surface border border-xmr-border/15 rounded-lg" style={{ transform: 'translateY(-6px) scale(0.96)', opacity: 0.25 }} />
+            <div className="absolute top-0 left-8 right-8 h-full bg-xmr-surface border border-xmr-border/15 rounded-sm" style={{ transform: 'translateY(-6px) scale(0.96)', opacity: 0.25 }} />
           )}
           {accounts.length >= 2 && (
-            <div className="absolute top-0 left-4 right-4 h-full bg-xmr-surface border border-xmr-border/20 rounded-lg" style={{ transform: 'translateY(-3px) scale(0.98)', opacity: 0.4 }} />
+            <div className="absolute top-0 left-4 right-4 h-full bg-xmr-surface border border-xmr-border/20 rounded-sm" style={{ transform: 'translateY(-3px) scale(0.98)', opacity: 0.4 }} />
           )}
 
           {/* Main card */}
-          <div className={`relative bg-gradient-to-br from-xmr-green/5 via-xmr-green/8 to-xmr-green/3 bg-xmr-surface border border-xmr-green/40 rounded-lg shadow-[0_8px_32px_rgba(0,0,0,0.5)] transition-all duration-150 ${switching ? 'opacity-70 scale-[0.99]' : 'opacity-100 scale-100'}`}>
+          <div className={`relative bg-gradient-to-br from-xmr-green/5 via-xmr-green/8 to-xmr-green/3 bg-xmr-surface border border-xmr-green/40 rounded-sm shadow-[0_8px_32px_rgba(0,0,0,0.5)] transition-all duration-150 ${switching ? 'opacity-70 scale-[0.99]' : 'opacity-100 scale-100'}`}>
             {/* Top glow */}
-            <div className="absolute top-0 left-0 right-0 h-[2px] bg-gradient-to-r from-transparent via-xmr-green/50 to-transparent rounded-t-lg" />
+            <div className="absolute top-0 left-0 right-0 h-[2px] bg-gradient-to-r from-transparent via-xmr-green/50 to-transparent rounded-t-sm" />
             {/* Watermark */}
             <div className="absolute right-6 bottom-3 text-8xl font-black text-xmr-green/[0.03] tracking-tighter select-none pointer-events-none">XMR</div>
 
@@ -257,12 +257,12 @@ export function VaultView({ setView, vault, handleBurn, appConfig }: VaultViewPr
                   <div className="relative shrink-0" ref={cardMenuRef}>
                     <button
                       onClick={() => setShowCardMenu(!showCardMenu)}
-                      className="w-7 h-7 flex items-center justify-center border border-xmr-border/20 rounded-md text-xmr-dim hover:text-xmr-green hover:border-xmr-green/50 hover:bg-xmr-green/10 transition-all cursor-pointer"
+                      className="w-7 h-7 flex items-center justify-center border border-xmr-border/20 rounded-sm text-xmr-dim hover:text-xmr-green hover:border-xmr-green/50 hover:bg-xmr-green/10 transition-all cursor-pointer"
                     >
                       <MoreVertical size={14} />
                     </button>
                     {showCardMenu && (
-                      <div className="absolute right-0 top-9 bg-xmr-base border border-xmr-border/50 rounded-md shadow-xl z-50 min-w-[180px] py-1 animate-in fade-in zoom-in-95 duration-150">
+                      <div className="absolute right-0 top-9 bg-xmr-base border border-xmr-border/50 rounded-sm shadow-xl z-50 min-w-[180px] py-1 animate-in fade-in zoom-in-95 duration-150">
                         <button
                           onClick={() => { setEditAccountName(currentAcc?.label || ''); setEditingAccountId(selectedAccountIndex); setShowCardMenu(false); }}
                           className="w-full px-4 py-2.5 text-left text-[11px] font-black uppercase tracking-widest text-xmr-dim hover:text-xmr-green hover:bg-xmr-green/10 transition-all flex items-center gap-2 cursor-pointer"
@@ -308,7 +308,7 @@ export function VaultView({ setView, vault, handleBurn, appConfig }: VaultViewPr
                       key={action.label}
                       onClick={action.onClick}
                       disabled={action.disabled}
-                      className="flex items-center gap-2 px-4 py-2 rounded-lg border border-xmr-green/20 bg-xmr-base/40 text-xmr-green hover:border-xmr-green/50 hover:bg-xmr-green/10 transition-all cursor-pointer disabled:opacity-30 disabled:cursor-not-allowed group"
+                      className="flex items-center gap-2 px-4 py-2 rounded-sm border border-xmr-green/20 bg-xmr-base/40 text-xmr-green hover:border-xmr-green/50 hover:bg-xmr-green/10 transition-all cursor-pointer disabled:opacity-30 disabled:cursor-not-allowed group"
                     >
                       <action.icon size={14} className={action.spin ? 'animate-spin' : ''} />
                       <span className="text-[9px] font-bold uppercase tracking-[0.12em] group-hover:text-xmr-green transition-colors">
@@ -364,7 +364,7 @@ export function VaultView({ setView, vault, handleBurn, appConfig }: VaultViewPr
                     <span className="text-xmr-green/60">{currentAccIdx + 1}/{accounts.length}</span>
                   </button>
                   {showAccountList && (
-                    <div className="absolute bottom-10 right-0 bg-xmr-base border border-xmr-border/50 rounded-md shadow-2xl z-50 w-[340px] max-h-[400px] flex flex-col animate-in fade-in slide-in-from-bottom-2 duration-150">
+                    <div className="absolute bottom-10 right-0 bg-xmr-base border border-xmr-border/50 rounded-sm shadow-2xl z-50 w-[340px] max-h-[400px] flex flex-col animate-in fade-in slide-in-from-bottom-2 duration-150">
                       <div className="px-4 py-3 border-b border-xmr-border/30 bg-xmr-green/5">
                         <div className="flex justify-between items-center mb-1">
                           <span className="text-[10px] font-black uppercase tracking-widest text-xmr-dim">All Accounts ({accounts.length})</span>
@@ -414,7 +414,7 @@ export function VaultView({ setView, vault, handleBurn, appConfig }: VaultViewPr
       </div>
 
       {/* 3. TABS + CONTENT (or inline Send/Receive panel) */}
-      <div className="min-h-[400px] border border-xmr-border/20 rounded-lg overflow-hidden bg-xmr-surface/30">
+      <div className="min-h-[400px] border border-xmr-border/20 rounded-sm overflow-hidden bg-xmr-surface/30">
         {activePanel === 'send' ? (
           <DispatchModal
             inline
@@ -436,7 +436,7 @@ export function VaultView({ setView, vault, handleBurn, appConfig }: VaultViewPr
                 <button
                   key={t}
                   onClick={() => setTab(t as any)}
-                  className={`px-4 py-2 text-[11px] font-black uppercase tracking-widest transition-all rounded-lg ${tab === t ? 'text-xmr-green border border-xmr-green/30 bg-xmr-green/5' : 'text-xmr-dim hover:text-xmr-green border border-transparent'}`}
+                  className={`px-4 py-2 text-[11px] font-black uppercase tracking-widest transition-all rounded-sm ${tab === t ? 'text-xmr-green border border-xmr-green/30 bg-xmr-green/5' : 'text-xmr-dim hover:text-xmr-green border border-transparent'}`}
                 >
                   {t}
                 </button>

--- a/src/renderer/components/VaultView.tsx
+++ b/src/renderer/components/VaultView.tsx
@@ -358,7 +358,7 @@ export function VaultView({ setView, vault, handleBurn, appConfig }: VaultViewPr
                 <div className="relative mt-3 pt-3 border-t border-xmr-border/15" ref={accountListRef}>
                   <button
                     onClick={() => setShowAccountList(!showAccountList)}
-                    className="w-full flex items-center justify-between text-[10px] font-black text-xmr-dim hover:text-xmr-green transition-colors cursor-pointer uppercase tracking-widest px-2.5 py-1.5 border border-xmr-border/20 rounded hover:border-xmr-green/40"
+                    className="w-full flex items-center justify-between text-[10px] font-black text-xmr-dim hover:text-xmr-green transition-colors cursor-pointer uppercase tracking-widest px-2.5 py-1.5 border border-xmr-border/20 rounded-sm hover:border-xmr-green/40"
                   >
                     <span>All Accounts</span>
                     <span className="text-xmr-green/60">{currentAccIdx + 1}/{accounts.length}</span>

--- a/src/renderer/components/VigilView.tsx
+++ b/src/renderer/components/VigilView.tsx
@@ -155,7 +155,7 @@ export function VigilView({ localXmrAddress }: VigilViewProps) {
         ${isDanger ? 'bg-xmr-error/10 border-xmr-error/30' : 'bg-xmr-base/30 border-xmr-border'}
       `}>
         <div className="flex items-center gap-2">
-          <div className={`p-1.5 rounded border transition-colors
+          <div className={`p-1.5 rounded-sm border transition-colors
             ${isDanger
               ? 'bg-xmr-error/20 border-xmr-error text-xmr-error'
               : 'bg-xmr-ghost/10 border-xmr-ghost/20 text-xmr-ghost'
@@ -296,7 +296,7 @@ export function VigilView({ localXmrAddress }: VigilViewProps) {
                     Send the input amount to complete the swap
                   </p>
                 </div>
-                <div className="p-3 bg-xmr-base border border-xmr-accent/20 rounded space-y-2">
+                <div className="p-3 bg-xmr-base border border-xmr-accent/20 rounded-sm space-y-2">
                   <div className="flex justify-between text-[10px] font-mono uppercase">
                     <span className="text-xmr-dim">Amount</span>
                     <span className="text-xmr-accent font-bold">

--- a/src/renderer/components/VigilView.tsx
+++ b/src/renderer/components/VigilView.tsx
@@ -135,7 +135,7 @@ export function VigilView({ localXmrAddress }: VigilViewProps) {
 
   return (
     <div className={`
-      border rounded-lg overflow-hidden backdrop-blur-md flex flex-col relative shadow-xl transition-all duration-500
+      border rounded-sm overflow-hidden backdrop-blur-md flex flex-col relative shadow-xl transition-all duration-500
       ${isDanger
         ? 'bg-xmr-error/20 border-xmr-error/50 shadow-[0_0_50px_rgba(239,68,68,0.3)]'
         : 'bg-xmr-surface border-xmr-border'
@@ -227,7 +227,7 @@ export function VigilView({ localXmrAddress }: VigilViewProps) {
             </div>
 
             {/* Inline log stream */}
-            <div className="w-full max-w-xl bg-xmr-base border border-xmr-border/20 rounded-lg p-3 max-h-[200px] overflow-y-auto font-mono text-[10px] space-y-0.5 custom-scrollbar">
+            <div className="w-full max-w-xl bg-xmr-base border border-xmr-border/20 rounded-sm p-3 max-h-[200px] overflow-y-auto font-mono text-[10px] space-y-0.5 custom-scrollbar">
               {logs.map((log) => (
                 <div key={log.id} className={`flex gap-2 ${log.type === 'error' ? 'text-xmr-error' : log.type === 'success' ? 'text-xmr-green' : 'text-xmr-dim'}`}>
                   <span className="text-xmr-dim/40 shrink-0">{log.time}</span>
@@ -342,7 +342,7 @@ export function VigilView({ localXmrAddress }: VigilViewProps) {
             </div>
 
             {/* Error logs */}
-            <div className="w-full max-w-xl bg-xmr-base border border-xmr-error/20 rounded-lg p-3 max-h-[150px] overflow-y-auto font-mono text-[10px] space-y-0.5 custom-scrollbar">
+            <div className="w-full max-w-xl bg-xmr-base border border-xmr-error/20 rounded-sm p-3 max-h-[150px] overflow-y-auto font-mono text-[10px] space-y-0.5 custom-scrollbar">
               {logs.filter((l) => l.type === 'error').map((log) => (
                 <div key={log.id} className="text-xmr-error">
                   <span className="text-xmr-dim/40 mr-2">{log.time}</span>

--- a/src/renderer/components/auth/AuthForm.tsx
+++ b/src/renderer/components/auth/AuthForm.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type { FormEvent } from 'react';
 import { Lock, Skull, RefreshCw, Key, Download, Sparkles, ArrowLeft, Calendar } from 'lucide-react';
 
 interface LogEntry {
@@ -25,8 +25,7 @@ interface AuthFormProps {
   logs: LogEntry[];
   
   // Actions
-  handleUnlockSubmit: (e: React.FormEvent) => void;
-  handleCreateFinalize: () => void; 
+  handleUnlockSubmit: (e: FormEvent) => void;
 }
 
 export function AuthForm({ 

--- a/src/renderer/components/auth/IdentitySwitcher.tsx
+++ b/src/renderer/components/auth/IdentitySwitcher.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { PlusCircle, Check, Trash2, ChevronDown, ChevronUp, Users } from 'lucide-react';
 
 interface Identity {

--- a/src/renderer/components/auth/IdentitySwitcher.tsx
+++ b/src/renderer/components/auth/IdentitySwitcher.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { PlusCircle, Check, Trash2, ChevronDown, ChevronUp, Users, AlertCircle } from 'lucide-react';
+import { PlusCircle, Check, Trash2, ChevronDown, ChevronUp, Users } from 'lucide-react';
 
 interface Identity {
   id: string;

--- a/src/renderer/components/common/AddressDisplay.tsx
+++ b/src/renderer/components/common/AddressDisplay.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type { MouseEvent } from 'react';
 import { Copy, Check } from 'lucide-react';
 import { useCopyToClipboard } from '../../hooks/useCopyToClipboard';
 
@@ -18,7 +18,7 @@ interface AddressDisplayProps {
 export function AddressDisplay({ address, className = '', truncate = false, length = 12, showCopyIndicator = false }: AddressDisplayProps) {
   const { copied, copy } = useCopyToClipboard();
 
-  const handleCopy = (e: React.MouseEvent) => {
+  const handleCopy = (e: MouseEvent) => {
     e.stopPropagation();
     copy(address);
   };
@@ -52,7 +52,7 @@ export function AddressDisplay({ address, className = '', truncate = false, leng
     >
       <code className={`font-mono flex flex-wrap gap-x-1 group-hover:opacity-80 transition-colors`}>
         {copied && <div className={`absolute flex items-center gap-1 transition-all duration-300 ${copied ? 'opacity-100 translate-x-0' : 'opacity-0 -translate-x-2 pointer-events-none'}`}>
-          <span className="text-xs font-black bg-xmr-green text-xmr-base px-1 rounded leading-tight">COPIED</span>
+          <span className="text-xs font-black bg-xmr-green text-xmr-base px-1 rounded-sm leading-tight">COPIED</span>
           <Check size={10} className="text-xmr-green" />
         </div>}
         {formattedBlocks}

--- a/src/renderer/components/common/XMR402Modal.tsx
+++ b/src/renderer/components/common/XMR402Modal.tsx
@@ -142,7 +142,7 @@ export const XMR402Modal: React.FC = () => {
           initial={{ scale: 0.9, opacity: 0, y: 20 }}
           animate={{ scale: 1, opacity: 1, y: 0 }}
           exit={{ scale: 0.9, opacity: 0, y: 20 }}
-          className="w-full max-w-lg bg-xmr-base border border-xmr-accent/30 shadow-[0_0_50px_rgba(0,255,65,0.1)] overflow-hidden rounded-lg"
+          className="w-full max-w-lg bg-xmr-base border border-xmr-accent/30 shadow-[0_0_50px_rgba(0,255,65,0.1)] overflow-hidden rounded-sm"
         >
           {/* Header */}
           <div className="bg-xmr-accent/10 border-b border-xmr-accent/20 p-4 flex justify-between items-center">

--- a/src/renderer/components/vault/AddressBook.tsx
+++ b/src/renderer/components/vault/AddressBook.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { Book, PlusCircle, X } from 'lucide-react';
 import { Card } from '../Card';
 import { TableHeader } from './TableHeader';

--- a/src/renderer/components/vault/AddressList.tsx
+++ b/src/renderer/components/vault/AddressList.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState, type MouseEvent } from 'react';
 import { Copy, Edit2, Check, X, Wind, Send } from 'lucide-react';
 import { Card } from '../Card';
 import { TableHeader } from './TableHeader';
@@ -36,7 +36,7 @@ export function AddressList({
     }
   };
 
-  const handleVanish = async (e: React.MouseEvent, index: number) => {
+  const handleVanish = async (e: MouseEvent, index: number) => {
     e.stopPropagation();
     try {
       setVanishingIndex(index);

--- a/src/renderer/components/vault/AgentTab.tsx
+++ b/src/renderer/components/vault/AgentTab.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import { Bot, Shield, Zap, Key, RefreshCw, BarChart3, Activity, Terminal as TerminalIcon, ChevronDown, ChevronUp } from 'lucide-react';
 import { Card } from '../Card';
 import { useVault } from '../../hooks/useVault';

--- a/src/renderer/components/vault/ChurnModal.tsx
+++ b/src/renderer/components/vault/ChurnModal.tsx
@@ -26,7 +26,7 @@ export function ChurnModal({ onClose, onChurn, unlockedBalance }: ChurnModalProp
 
   return (
     <div className="fixed top-0 bottom-0 right-0 left-[14rem] z-[100] flex items-center justify-center p-6 bg-xmr-base/90 backdrop-blur-md animate-in fade-in duration-300">
-      <div className="w-full max-w-lg bg-xmr-base/80 text-xmr-dim p-8 border-4 border-xmr-green relative rounded-lg">
+      <div className="w-full max-w-lg bg-xmr-base/80 text-xmr-dim p-8 border-2 border-xmr-green relative rounded-sm">
         <button onClick={onClose} disabled={isProcessing} className="absolute top-4 right-4 cursor-pointer disabled:opacity-50">
           <X size={24} />
         </button>

--- a/src/renderer/components/vault/ChurnModal.tsx
+++ b/src/renderer/components/vault/ChurnModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { X, Wind, Loader2 } from 'lucide-react';
 
 interface ChurnModalProps {

--- a/src/renderer/components/vault/CoinControl.tsx
+++ b/src/renderer/components/vault/CoinControl.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { Coins, Shield, Lock as LockIcon, Wind, Send } from 'lucide-react';
 import { Card } from '../Card';
 import { TableHeader } from './TableHeader';

--- a/src/renderer/components/vault/DirectSendTab.tsx
+++ b/src/renderer/components/vault/DirectSendTab.tsx
@@ -360,7 +360,7 @@ export function DirectSendTab({
                       <img
                         src={bioProfile.avatar}
                         alt="Avatar"
-                        className="w-10 h-10 rounded bg-black object-cover border border-xmr-green/30"
+                        className="w-10 h-10 rounded-sm bg-black object-cover border border-xmr-green/30"
                       />
                     )}
                     <div>

--- a/src/renderer/components/vault/DirectSendTab.tsx
+++ b/src/renderer/components/vault/DirectSendTab.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { Wallet, DollarSign, Send, Loader2, CheckCircle2, ChevronDown, ChevronUp, Coins, Copy, AlertTriangle, Info, ExternalLink } from 'lucide-react';
 import { useVault } from '../../contexts/VaultContext';
 import { useStats } from '../../hooks/useStats';

--- a/src/renderer/components/vault/DispatchModal.tsx
+++ b/src/renderer/components/vault/DispatchModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef } from 'react';
+import { useState, useRef } from 'react';
 import { X, Send, Ghost } from 'lucide-react';
 import { useVault } from '../../contexts/VaultContext';
 import { DispatchPasswordGate } from './DispatchPasswordGate';

--- a/src/renderer/components/vault/DispatchModal.tsx
+++ b/src/renderer/components/vault/DispatchModal.tsx
@@ -49,7 +49,7 @@ export function DispatchModal({ onClose, initialAddress = '', sourceSubaddressIn
   };
 
   const content = (
-      <div className={`w-full ${inline ? '' : 'max-w-xl bg-xmr-surface border border-xmr-border rounded-lg'} relative flex flex-col ${inline ? 'h-full' : 'max-h-[85vh]'} overflow-hidden`}>
+      <div className={`w-full ${inline ? '' : 'max-w-xl bg-xmr-surface border border-xmr-border rounded-sm'} relative flex flex-col ${inline ? 'h-full' : 'max-h-[85vh]'} overflow-hidden`}>
         {/* ══ PASSWORD GATE ══ */}
         {showPasswordGate && (
           <DispatchPasswordGate
@@ -76,7 +76,7 @@ export function DispatchModal({ onClose, initialAddress = '', sourceSubaddressIn
               <button
                 key={t.id}
                 onClick={() => setTab(t.id)}
-                className={`px-4 py-2 text-[11px] font-black uppercase tracking-widest transition-all rounded-lg flex items-center gap-1.5 cursor-pointer ${
+                className={`px-4 py-2 text-[11px] font-black uppercase tracking-widest transition-all rounded-sm flex items-center gap-1.5 cursor-pointer ${
                   tab === t.id
                     ? 'text-xmr-accent border border-xmr-accent/30 bg-xmr-accent/5'
                     : 'text-xmr-dim hover:text-xmr-accent border border-transparent'

--- a/src/renderer/components/vault/DispatchPasswordGate.tsx
+++ b/src/renderer/components/vault/DispatchPasswordGate.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Lock, Loader2 } from 'lucide-react';
 
 interface DispatchPasswordGateProps {

--- a/src/renderer/components/vault/GhostSendTab.tsx
+++ b/src/renderer/components/vault/GhostSendTab.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { Ghost, ArrowRight, DollarSign, Loader2, CheckCircle2, AlertTriangle, Wallet, RefreshCw } from 'lucide-react';
 import { useVault } from '../../contexts/VaultContext';
 import { useStats } from '../../hooks/useStats';

--- a/src/renderer/components/vault/ReceiveModal.tsx
+++ b/src/renderer/components/vault/ReceiveModal.tsx
@@ -102,7 +102,7 @@ export function ReceiveModal({ onClose, existingAddress, inline }: ReceiveModalP
   );
 
   const content = (
-      <div className={`w-full ${inline ? '' : 'max-w-xl bg-xmr-surface border border-xmr-border rounded-lg'} relative flex flex-col ${inline ? 'h-full' : 'max-h-[85vh]'} overflow-hidden`}>
+      <div className={`w-full ${inline ? '' : 'max-w-xl bg-xmr-surface border border-xmr-border rounded-sm'} relative flex flex-col ${inline ? 'h-full' : 'max-h-[85vh]'} overflow-hidden`}>
 
         {/* Header — matches tab bar style when inline */}
         <div className={`flex items-center justify-between ${inline ? 'px-3 py-2 bg-xmr-surface/50' : 'px-6 py-4'} border-b border-xmr-border/${inline ? '15' : '40'}`}>
@@ -114,7 +114,7 @@ export function ReceiveModal({ onClose, existingAddress, inline }: ReceiveModalP
               <button
                 key={t.id}
                 onClick={() => setTab(t.id)}
-                className={`px-4 py-2 text-[11px] font-black uppercase tracking-widest transition-all rounded-lg flex items-center gap-1.5 cursor-pointer ${tab === t.id
+                className={`px-4 py-2 text-[11px] font-black uppercase tracking-widest transition-all rounded-sm flex items-center gap-1.5 cursor-pointer ${tab === t.id
                     ? 'text-xmr-green border border-xmr-green/30 bg-xmr-green/5'
                     : 'text-xmr-dim hover:text-xmr-green border border-transparent'
                   }`}

--- a/src/renderer/components/vault/ReceiveModal.tsx
+++ b/src/renderer/components/vault/ReceiveModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { X, Tag, DollarSign, Copy, CheckCircle2, QrCode, ArrowDownToLine, Shuffle } from 'lucide-react';
 import { QRCodeSVG } from 'qrcode.react';
 import { useVault } from '../../contexts/VaultContext';

--- a/src/renderer/components/vault/ReceiveModal.tsx
+++ b/src/renderer/components/vault/ReceiveModal.tsx
@@ -81,7 +81,7 @@ export function ReceiveModal({ onClose, existingAddress, inline }: ReceiveModalP
     copyText: string; copied: boolean; onCopy: () => void; sublabel?: string;
   }) => (
     <div className="flex flex-col items-center gap-4">
-      <div className="p-3 bg-white rounded">
+      <div className="p-3 bg-white rounded-sm">
         <QRCodeSVG
           value={qrValue} size={qrSize} level="M" includeMargin={false}
           imageSettings={imgSrc ? { src: imgSrc, x: undefined, y: undefined, height: imgSize || 34, width: imgSize || 34, excavate: true } : undefined}

--- a/src/renderer/components/vault/SplinterModal.tsx
+++ b/src/renderer/components/vault/SplinterModal.tsx
@@ -31,7 +31,7 @@ export function SplinterModal({ onClose, onSplinter, unlockedBalance }: Splinter
 
   return (
     <div className="fixed top-0 bottom-0 right-0 left-[14rem] z-[100] flex items-center justify-center p-6 bg-xmr-base/90 backdrop-blur-md animate-in fade-in duration-300">
-      <div className="w-full max-w-lg max-h-[90vh] bg-xmr-base/80 text-xmr-dim border-4 border-xmr-accent relative rounded-lg flex flex-col">
+      <div className="w-full max-w-lg max-h-[90vh] bg-xmr-base/80 text-xmr-dim border-2 border-xmr-accent relative rounded-sm flex flex-col">
         <button onClick={onClose} disabled={isProcessing} className="absolute top-4 right-4 cursor-pointer disabled:opacity-50 z-10">
           <X size={24} />
         </button>

--- a/src/renderer/components/vault/SplinterModal.tsx
+++ b/src/renderer/components/vault/SplinterModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { X, Scissors, Loader2 } from 'lucide-react';
 
 interface SplinterModalProps {

--- a/src/renderer/components/vault/TransactionLedger.tsx
+++ b/src/renderer/components/vault/TransactionLedger.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import { ArrowDownLeft, ArrowUpRight, ChevronDown, ChevronUp, Copy, ExternalLink, Info, Loader2, Key, ShieldCheck, Fingerprint, CheckCircle, ShieldAlert, Zap, Ghost } from 'lucide-react';
 import { Card } from '../Card';
 import { TableHeader } from './TableHeader';

--- a/src/renderer/components/vault/TransactionLedger.tsx
+++ b/src/renderer/components/vault/TransactionLedger.tsx
@@ -372,10 +372,10 @@ export function TransactionLedger({ txs, subaddresses = [] }: TransactionLedgerP
                               {isIncoming ? 'Received' : 'Dispatched'}
                             </span>
                             {ghostTrades[tx.id] && (
-                              <span className="text-[7px] px-1.5 py-0.5 bg-xmr-accent/10 border border-xmr-accent/20 rounded text-xmr-accent font-black tracking-wider">Ghost</span>
+                              <span className="text-[7px] px-1.5 py-0.5 bg-xmr-accent/10 border border-xmr-accent/20 rounded-sm text-xmr-accent font-black tracking-wider">Ghost</span>
                             )}
                             {xmr402Info && (
-                              <span className="text-[7px] px-1.5 py-0.5 bg-xmr-warning/10 border border-xmr-warning/20 rounded text-xmr-warning font-black tracking-wider">XMR402</span>
+                              <span className="text-[7px] px-1.5 py-0.5 bg-xmr-warning/10 border border-xmr-warning/20 rounded-sm text-xmr-warning font-black tracking-wider">XMR402</span>
                             )}
                           </div>
                           <div className="text-[9px] text-xmr-dim/40 mt-0.5 truncate">
@@ -593,7 +593,7 @@ export function TransactionLedger({ txs, subaddresses = [] }: TransactionLedgerP
                               ) : (
                                 <div className="text-xs font-mono text-xmr-dim opacity-60 flex items-center gap-2">
                                   <span>¿Unknown Destination?</span>
-                                  <span className="text-xs bg-xmr-dim/10 px-1 rounded uppercase tracking-tighter">Privacy Protected</span>
+                                  <span className="text-xs bg-xmr-dim/10 px-1 rounded-sm uppercase tracking-tighter">Privacy Protected</span>
                                 </div>
                               )}
                             </div>

--- a/src/renderer/components/vault/TransactionLedger.tsx
+++ b/src/renderer/components/vault/TransactionLedger.tsx
@@ -357,7 +357,7 @@ export function TransactionLedger({ txs, subaddresses = [] }: TransactionLedgerP
                         <div className={`absolute left-0 top-0 bottom-0 w-[2px] opacity-0 group-hover:opacity-100 transition-opacity ${isIncoming ? 'bg-xmr-green' : 'bg-xmr-accent'}`} />
 
                         {/* Type indicator */}
-                        <div className={`w-7 h-7 rounded-md flex items-center justify-center mr-3 shrink-0 ${isIncoming ? 'bg-xmr-green/8 border border-xmr-green/20' : 'bg-xmr-accent/8 border border-xmr-accent/20'}`}>
+                        <div className={`w-7 h-7 rounded-sm flex items-center justify-center mr-3 shrink-0 ${isIncoming ? 'bg-xmr-green/8 border border-xmr-green/20' : 'bg-xmr-accent/8 border border-xmr-accent/20'}`}>
                           {isIncoming ? (
                             <ArrowDownLeft size={13} className="text-xmr-green" />
                           ) : (

--- a/src/renderer/components/vault/VaultModals.tsx
+++ b/src/renderer/components/vault/VaultModals.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import { X, ShieldAlert } from 'lucide-react';
 import { ReceiveModal } from './ReceiveModal';
 import { DispatchModal } from './DispatchModal';

--- a/src/renderer/components/vault/VaultModals.tsx
+++ b/src/renderer/components/vault/VaultModals.tsx
@@ -50,12 +50,12 @@ export function VaultModals({
       {/* SEED MODAL */}
       {showSeed && (
         <div className="fixed top-0 bottom-0 right-0 left-[14rem] z-[100] flex items-center justify-center p-6 bg-xmr-base/90 backdrop-blur-md animate-in fade-in duration-300">
-          <div className="w-full max-w-lg bg-white text-black p-8 border-4 border-xmr-error relative rounded-lg">
-            <button onClick={onCloseSeed} className="absolute top-4 right-4 cursor-pointer"><X size={24} /></button>
+          <div className="w-full max-w-lg bg-xmr-surface p-8 border-2 border-xmr-error/50 relative rounded-sm">
+            <button onClick={onCloseSeed} className="absolute top-4 right-4 text-xmr-dim hover:text-xmr-error cursor-pointer"><X size={24} /></button>
             <div className="space-y-6 font-black">
               <div className="flex items-center gap-3 text-xmr-error animate-pulse font-black"><ShieldAlert size={32} /><h3 className="text-2xl font-black uppercase tracking-tighter">Backup_Protocol</h3></div>
-              <div className="p-4 bg-black/5 border border-black/10 rounded-sm font-black text-sm leading-loose select-text text-black">{mnemonic}</div>
-              <button onClick={onCloseSeed} className="w-full py-4 bg-black text-white font-black uppercase tracking-[0.2em] font-mono cursor-pointer">I_HAVE_SECURED_THE_KEY</button>
+              <div className="p-4 bg-xmr-base border border-xmr-error/20 rounded-sm font-black text-sm leading-loose select-text text-xmr-green">{mnemonic}</div>
+              <button onClick={onCloseSeed} className="w-full py-4 bg-xmr-error text-xmr-base font-black uppercase tracking-[0.2em] font-mono cursor-pointer hover:brightness-110 transition-all">I_HAVE_SECURED_THE_KEY</button>
             </div>
           </div>
         </div>

--- a/src/renderer/components/vigil/VigilConfig.tsx
+++ b/src/renderer/components/vigil/VigilConfig.tsx
@@ -323,7 +323,7 @@ export function VigilConfig({ mode, setMode, data, setData, onArm, currentPrice 
         {/* Header */}
         <div className="flex justify-between items-end border-b border-xmr-border/30 pb-1.5">
           <div className="flex items-center gap-2">
-            <div className={`p-1 rounded ${useStop ? 'bg-xmr-ghost/20 text-xmr-ghost' : 'bg-xmr-dim/10 text-xmr-dim'}`}>
+            <div className={`p-1 rounded-sm ${useStop ? 'bg-xmr-ghost/20 text-xmr-ghost' : 'bg-xmr-dim/10 text-xmr-dim'}`}>
               <Activity size={12} />
             </div>
             <span className="text-[10px] text-xmr-dim font-mono uppercase tracking-widest">
@@ -331,7 +331,7 @@ export function VigilConfig({ mode, setMode, data, setData, onArm, currentPrice 
             </span>
           </div>
 
-          <div className="flex items-center gap-2 bg-black/40 px-2 py-1 rounded border border-xmr-border/30">
+          <div className="flex items-center gap-2 bg-black/40 px-2 py-1 rounded-sm border border-xmr-border/30">
             <span className="relative flex h-1.5 w-1.5">
               <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-xmr-green opacity-75" />
               <span className="relative inline-flex rounded-full h-1.5 w-1.5 bg-xmr-green" />
@@ -357,7 +357,7 @@ export function VigilConfig({ mode, setMode, data, setData, onArm, currentPrice 
                 placeholder="0.00"
                 value={data.triggerPrice}
                 onChange={(e: any) => setData({ ...data, triggerPrice: e.target.value })}
-                className={`w-full bg-xmr-base border rounded py-2 px-3 pl-6 text-sm font-mono text-current focus:outline-none transition-colors
+                className={`w-full bg-xmr-base border rounded-sm py-2 px-3 pl-6 text-sm font-mono text-current focus:outline-none transition-colors
                   ${mainStatus === 'immediate' ? 'border-xmr-warning text-xmr-warning' : 'border-xmr-border focus:border-xmr-ghost'}
                 `}
               />
@@ -381,7 +381,7 @@ export function VigilConfig({ mode, setMode, data, setData, onArm, currentPrice 
                   placeholder="0.00"
                   value={data.stopPrice}
                   onChange={(e: any) => setData({ ...data, stopPrice: e.target.value })}
-                  className={`w-full bg-xmr-base border rounded py-2 px-3 pl-6 text-sm font-mono text-current focus:outline-none transition-colors
+                  className={`w-full bg-xmr-base border rounded-sm py-2 px-3 pl-6 text-sm font-mono text-current focus:outline-none transition-colors
                     ${stopStatus === 'immediate' ? 'border-xmr-warning text-xmr-warning' : 'border-xmr-border focus:border-xmr-error/50'}
                   `}
                 />
@@ -400,7 +400,7 @@ export function VigilConfig({ mode, setMode, data, setData, onArm, currentPrice 
               if (useStop) setData({ ...data, stopPrice: '' });
               setUseStop(!useStop);
             }}
-            className={`text-[9px] uppercase tracking-wider border rounded px-3 py-1.5 transition-all flex items-center gap-2
+            className={`text-[9px] uppercase tracking-wider border rounded-sm px-3 py-1.5 transition-all flex items-center gap-2
               ${useStop
                 ? 'bg-xmr-ghost/10 border-xmr-ghost text-xmr-ghost shadow-[0_0_10px_rgba(168,85,247,0.2)]'
                 : 'border-xmr-border text-xmr-dim hover:text-xmr-green hover:border-xmr-dim'
@@ -477,7 +477,7 @@ export function VigilConfig({ mode, setMode, data, setData, onArm, currentPrice 
             }
             value={data.targetAddress}
             onChange={(e: any) => setData({ ...data, targetAddress: e.target.value })}
-            className={`w-full bg-xmr-base border rounded py-2 px-3 font-mono text-xs text-current focus:outline-none transition-colors placeholder:text-xmr-dim/30
+            className={`w-full bg-xmr-base border rounded-sm py-2 px-3 font-mono text-xs text-current focus:outline-none transition-colors placeholder:text-xmr-dim/30
               ${data.targetAddress && !isValid && !isValidating ? 'border-xmr-error/50 focus:border-xmr-error' : 'border-xmr-border focus:border-xmr-ghost'}
             `}
           />
@@ -491,7 +491,7 @@ export function VigilConfig({ mode, setMode, data, setData, onArm, currentPrice 
                 placeholder="0 (Required by destination)"
                 value={data.memo || ''}
                 onChange={(e: any) => setData({ ...data, memo: e.target.value })}
-                className="w-full bg-xmr-base border border-xmr-border rounded py-2 px-3 font-mono text-xs text-current focus:outline-none focus:border-xmr-ghost"
+                className="w-full bg-xmr-base border border-xmr-border rounded-sm py-2 px-3 font-mono text-xs text-current focus:outline-none focus:border-xmr-ghost"
               />
             </div>
           )}

--- a/src/renderer/components/vigil/VigilConfig.tsx
+++ b/src/renderer/components/vigil/VigilConfig.tsx
@@ -318,7 +318,7 @@ export function VigilConfig({ mode, setMode, data, setData, onArm, currentPrice 
       </div>
 
       {/* ─── Config Panel ─── */}
-      <div className="bg-xmr-base/30 border border-xmr-border rounded-md p-3 flex flex-col gap-3 relative">
+      <div className="bg-xmr-base/30 border border-xmr-border rounded-sm p-3 flex flex-col gap-3 relative">
 
         {/* Header */}
         <div className="flex justify-between items-end border-b border-xmr-border/30 pb-1.5">

--- a/src/renderer/components/vigil/VigilDashboard.tsx
+++ b/src/renderer/components/vigil/VigilDashboard.tsx
@@ -92,7 +92,7 @@ export function VigilDashboard({
     <div className="w-full max-w-4xl mx-auto space-y-4 animate-in fade-in duration-300">
 
       {/* ─── Price Display ─── */}
-      <div className="relative bg-xmr-base/50 border border-xmr-border/30 rounded-md p-6 overflow-hidden">
+      <div className="relative bg-xmr-base/50 border border-xmr-border/30 rounded-sm p-6 overflow-hidden">
         {/* Background glow when triggered */}
         {isTriggered && (
           <div className="absolute inset-0 bg-xmr-error/5 animate-pulse" />
@@ -226,7 +226,7 @@ export function VigilDashboard({
       </div>
 
       {/* ─── Log Output ─── */}
-      <div className="bg-xmr-base border border-xmr-border/20 rounded-md overflow-hidden">
+      <div className="bg-xmr-base border border-xmr-border/20 rounded-sm overflow-hidden">
         <div className="flex items-center justify-between px-3 py-2 border-b border-xmr-border/20 bg-xmr-surface/30">
           <div className="flex items-center gap-2">
             <span className="relative flex h-1.5 w-1.5">

--- a/src/renderer/components/vigil/VigilDashboard.tsx
+++ b/src/renderer/components/vigil/VigilDashboard.tsx
@@ -122,7 +122,7 @@ export function VigilDashboard({
             </div>
 
             <div className="flex flex-col items-end gap-2">
-              <div className={`flex items-center gap-2 text-[10px] font-mono px-2 py-1 rounded border backdrop-blur-sm
+              <div className={`flex items-center gap-2 text-[10px] font-mono px-2 py-1 rounded-sm border backdrop-blur-sm
                 ${priceConnected
                   ? 'text-xmr-green border-xmr-green/20 bg-xmr-green/5'
                   : 'text-xmr-error border-xmr-error/20 bg-xmr-error/5 animate-pulse'
@@ -132,7 +132,7 @@ export function VigilDashboard({
                 {priceConnected ? 'LIVE FEED' : 'CONNECTING...'}
               </div>
 
-              <div className={`text-[9px] font-mono uppercase tracking-widest px-2 py-1 rounded border
+              <div className={`text-[9px] font-mono uppercase tracking-widest px-2 py-1 rounded-sm border
                 ${isTriggered
                   ? 'text-xmr-error border-xmr-error/30 bg-xmr-error/10 animate-pulse'
                   : 'text-xmr-ghost border-xmr-ghost/20 bg-xmr-ghost/5'
@@ -146,7 +146,7 @@ export function VigilDashboard({
           {/* ─── Target Lines ─── */}
           <div className="grid grid-cols-2 gap-4">
             {/* Main Target */}
-            <div className="p-3 rounded border border-xmr-green/20 bg-xmr-green/5 space-y-1">
+            <div className="p-3 rounded-sm border border-xmr-green/20 bg-xmr-green/5 space-y-1">
               <div className="text-[9px] text-xmr-dim font-mono uppercase tracking-widest flex items-center gap-1.5">
                 <div className="w-1.5 h-1.5 rounded-full bg-xmr-green" />
                 {mode === 'SNIPE' ? 'BUY DIP TARGET' : 'TAKE PROFIT TARGET'}
@@ -158,7 +158,7 @@ export function VigilDashboard({
             </div>
 
             {/* Stop / Strategy */}
-            <div className={`p-3 rounded border space-y-1
+            <div className={`p-3 rounded-sm border space-y-1
               ${hasStop
                 ? 'border-xmr-error/20 bg-xmr-error/5'
                 : 'border-xmr-border/20 bg-xmr-surface/30'
@@ -190,21 +190,21 @@ export function VigilDashboard({
 
       {/* ─── Mission Parameters ─── */}
       <div className="grid grid-cols-3 gap-3">
-        <div className="bg-xmr-surface/50 border border-xmr-border/20 rounded p-3 space-y-1">
+        <div className="bg-xmr-surface/50 border border-xmr-border/20 rounded-sm p-3 space-y-1">
           <div className="text-[9px] text-xmr-dim font-mono uppercase tracking-widest">Amount</div>
           <div className="text-sm font-black font-mono text-xmr-green">
             {config.amount} {config.inputCurrency?.ticker?.toUpperCase() || 'XMR'}
           </div>
         </div>
 
-        <div className="bg-xmr-surface/50 border border-xmr-border/20 rounded p-3 space-y-1">
+        <div className="bg-xmr-surface/50 border border-xmr-border/20 rounded-sm p-3 space-y-1">
           <div className="text-[9px] text-xmr-dim font-mono uppercase tracking-widest">Output</div>
           <div className="text-sm font-black font-mono text-xmr-green">
             {config.outputCurrency?.ticker?.toUpperCase() || 'USDT'}
           </div>
         </div>
 
-        <div className="bg-xmr-surface/50 border border-xmr-border/20 rounded p-3 space-y-1 overflow-hidden">
+        <div className="bg-xmr-surface/50 border border-xmr-border/20 rounded-sm p-3 space-y-1 overflow-hidden">
           <div className="flex justify-between items-center">
             <div className="text-[9px] text-xmr-dim font-mono uppercase tracking-widest">Destination</div>
             {config.targetAddress && (

--- a/src/renderer/hooks/useFiatValue.ts
+++ b/src/renderer/hooks/useFiatValue.ts
@@ -66,7 +66,6 @@ export function useFiatValue(ticker?: string, amount?: string | number, withPref
     const cachedData = priceCache[sym];
 
     if (cachedData && (now - cachedData.timestamp < CACHE_DURATION)) {
-      // console.log(`[FiatCache] Hit for ${sym}: $${cachedData.price}`);
       updateUI(cachedData.price);
       return;
     }


### PR DESCRIPTION
## Summary
- Standardize all component border-radius to `rounded-sm` (skin-aware CSS variable `--radius-sm`) instead of inconsistent `rounded-md`/`rounded-lg` across 19 files — ensures UI respects the active skin's radius tokens (terminal/clean/monero)
- Remove unused icon imports (`AlertCircle`, `Info`, `Shield`, `Zap`) from HomeView, SettingsView, and IdentitySwitcher
- Theme the seed backup modal with skin-aware colors instead of hardcoded `bg-white`/`text-black` — now works correctly in all themes
- Normalize modal border widths from `border-4` to `border-2` for visual consistency

## Test plan
- [ ] Verify all skins (terminal, clean, monero) render correct border radius
- [ ] Confirm seed backup modal is legible in both light and dark modes
- [ ] Check all modals (churn, splinter, dispatch, receive, XMR402) have consistent rounding
- [ ] Verify ExchangeView route cards, mode tabs, and buttons match
- [ ] Ensure VaultView card stack, tabs, and dropdowns are consistent

🤖 Generated with [Claude Code](https://claude.com/claude-code)