### PR TITLE
feat: complete Vigil/Limit — strike wallet, real tracking, persistence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,10 @@ dist-ssr
 
 # Binaries
 resources/bin/
+
+# Tauri migration experiments (separate toolchain, not part of Electron builds)
+src-tauri/
+
+# Local agent tooling
+.ccb/
+opencode.json

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <title>GHOST_TERMINAL :: KYC.RIP</title>
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; frame-src https://kyc.rip; connect-src 'self' https://api.kyc.rip https://kyc.rip http://127.0.0.1:18082;"
+      content="default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; frame-src https://kyc.rip; connect-src 'self' https://api.kyc.rip https://kyc.rip wss://ws.kraken.com http://127.0.0.1:18082;"
     />
   </head>
   <body>

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "predev": "npm run setup-bins",
     "prestart": "npm run setup-bins",
     "deploy:public": "cd .. && ./deploy-public.sh",
-    "deploy:subtree": "cd .. && git subtree push --prefix desktop git@github-xbtoshi:KYC-rip/ghost-terminal.git main"
+    "deploy:subtree": "cd .. && git subtree push --prefix desktop git@github-xbtoshi:KYC-rip/ghost-terminal.git main",
+    "test": "vitest run"
   },
   "build": {
     "publish": [
@@ -71,6 +72,7 @@
     ]
   },
   "dependencies": {
+    "@kyc-rip/stealth-engines": "git+https://github.com/KYC-rip/stealth-engines.git",
     "electron-store": "^11.0.2",
     "ethers": "6.16.0",
     "framer-motion": "12.34.0",
@@ -105,7 +107,8 @@
     "postcss": "8.5.6",
     "tailwindcss": "4.1.18",
     "typescript": "5.9.3",
-    "vite": "7.3.1"
+    "vite": "7.3.1",
+    "vitest": "^4.1.8"
   },
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@kyc-rip/stealth-engines':
+        specifier: git+https://github.com/KYC-rip/stealth-engines.git
+        version: git+https://github.com/KYC-rip/stealth-engines.git#51679521a597a4e3a1e460a133c936ff9b2ddd7c(ethers@6.16.0)
       electron-store:
         specifier: ^11.0.2
         version: 11.0.2
@@ -108,6 +111,9 @@ importers:
       vite:
         specifier: 7.3.1
         version: 7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)
+      vitest:
+        specifier: ^4.1.8
+        version: 4.1.8(@types/node@25.2.3)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2))
 
 packages:
 
@@ -629,6 +635,16 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
+  '@kyc-rip/stealth-engines@git+https://github.com/KYC-rip/stealth-engines.git#51679521a597a4e3a1e460a133c936ff9b2ddd7c':
+    resolution: {commit: 51679521a597a4e3a1e460a133c936ff9b2ddd7c, repo: https://github.com/KYC-rip/stealth-engines.git, type: git}
+    version: 0.1.0
+    peerDependencies:
+      ethers: ^6.13.0
+      monero-ts: '>=0.11.0'
+    peerDependenciesMeta:
+      monero-ts:
+        optional: true
+
   '@malept/cross-spawn-promise@1.1.1':
     resolution: {integrity: sha512-RTBGWL5FWQcg9orDOCcp4LvItNzUPcyEU9bwaeJX0rJ1IQxzucC48Y0/sQLp/g6t99IQgAlGIaesJS+gTn7tVQ==}
     engines: {node: '>= 10'}
@@ -719,66 +735,79 @@ packages:
     resolution: {integrity: sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.59.0':
     resolution: {integrity: sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.59.0':
     resolution: {integrity: sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.59.0':
     resolution: {integrity: sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.59.0':
     resolution: {integrity: sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.59.0':
     resolution: {integrity: sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.59.0':
     resolution: {integrity: sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.59.0':
     resolution: {integrity: sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.59.0':
     resolution: {integrity: sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.59.0':
     resolution: {integrity: sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.59.0':
     resolution: {integrity: sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.59.0':
     resolution: {integrity: sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.59.0':
     resolution: {integrity: sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.59.0':
     resolution: {integrity: sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==}
@@ -813,6 +842,9 @@ packages:
   '@sindresorhus/is@4.6.0':
     resolution: {integrity: sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==}
     engines: {node: '>=10'}
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
   '@szmarczak/http-timer@4.0.6':
     resolution: {integrity: sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==}
@@ -856,24 +888,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.1.18':
     resolution: {integrity: sha512-1px92582HkPQlaaCkdRcio71p8bc8i/ap5807tPRDK/uw953cauQBT8c5tVGkOwrHMfc2Yh6UuxaH4vtTjGvHg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.1.18':
     resolution: {integrity: sha512-v3gyT0ivkfBLoZGF9LyHmts0Isc8jHZyVcbzio6Wpzifg/+5ZJpDiRiUhDLkcr7f/r38SWNe7ucxmGW3j3Kb/g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.1.18':
     resolution: {integrity: sha512-bhJ2y2OQNlcRwwgOAGMY0xTFStt4/wyU6pvI6LSuZpRgKQwxTec0/3Scu91O8ir7qCR3AuepQKLU/kX99FouqQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.1.18':
     resolution: {integrity: sha512-LffYTvPjODiP6PT16oNeUQJzNVyJl1cjIebq/rWWBF+3eDst5JGEFSc5cWxyRCJ0Mxl+KyIkqRxk1XPEs9x8TA==}
@@ -927,8 +963,14 @@ packages:
   '@types/cacheable-request@6.0.3':
     resolution: {integrity: sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==}
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
   '@types/debug@4.1.12':
     resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
@@ -1038,14 +1080,43 @@ packages:
     resolution: {integrity: sha512-cDF0/Gf81QpY3xYyJKDV14Zwdmid5+uuENhjH2EqFaF0ni+yAyq/LzMaIJdhNJXZI7uLzwIlA+V7oWoyn6Curg==}
     engines: {node: ^18.18.0 || >=20.0.0}
 
-  '@ungap/structured-clone@1.3.0':
-    resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+  '@ungap/structured-clone@1.3.1':
+    resolution: {integrity: sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==}
 
   '@vitejs/plugin-react@4.7.0':
     resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
+
+  '@vitest/expect@4.1.8':
+    resolution: {integrity: sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==}
+
+  '@vitest/mocker@4.1.8':
+    resolution: {integrity: sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.8':
+    resolution: {integrity: sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==}
+
+  '@vitest/runner@4.1.8':
+    resolution: {integrity: sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg==}
+
+  '@vitest/snapshot@4.1.8':
+    resolution: {integrity: sha512-acfZboRmAIf05DEKcBQy33VXojFJjtUdLyo7oOmV9kebb2xdU01UknNiPuPZoJZQyO7DF0gZdTGTpeAzET9QPQ==}
+
+  '@vitest/spy@4.1.8':
+    resolution: {integrity: sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA==}
+
+  '@vitest/utils@4.1.8':
+    resolution: {integrity: sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==}
 
   '@xmldom/xmldom@0.8.11':
     resolution: {integrity: sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==}
@@ -1083,6 +1154,9 @@ packages:
 
   ajv@6.14.0:
     resolution: {integrity: sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==}
+
+  ajv@6.15.0:
+    resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
 
   ajv@8.18.0:
     resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
@@ -1141,6 +1215,10 @@ packages:
 
   assert@2.1.0:
     resolution: {integrity: sha512-eLHpSK/Y4nhMJ07gDaAzoX/XAKS8PSaojml3M0DM4JpV1LAi5JOJ/p6H/XWrl8L+DzVEvVCW1z3vWAaB9oTsQw==}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
 
   astral-regex@2.0.0:
     resolution: {integrity: sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==}
@@ -1211,8 +1289,14 @@ packages:
   brace-expansion@1.1.12:
     resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
 
+  brace-expansion@1.1.15:
+    resolution: {integrity: sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==}
+
   brace-expansion@2.0.2:
     resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
+
+  brace-expansion@2.1.1:
+    resolution: {integrity: sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==}
 
   brace-expansion@5.0.3:
     resolution: {integrity: sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA==}
@@ -1309,6 +1393,10 @@ packages:
 
   caniuse-lite@1.0.30001774:
     resolution: {integrity: sha512-DDdwPGz99nmIEv216hKSgLD+D4ikHQHjBC/seF98N9CPqRX4M5mSxT9eTV6oyisnJcuzxtZy4n17yKKQYmYQOA==}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
 
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
@@ -1596,6 +1684,9 @@ packages:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
 
+  es-module-lexer@2.1.0:
+    resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
+
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
     engines: {node: '>= 0.4'}
@@ -1678,6 +1769,9 @@ packages:
   estree-walker@2.0.2:
     resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
@@ -1692,6 +1786,10 @@ packages:
 
   evp_bytestokey@1.0.3:
     resolution: {integrity: sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   extract-zip@2.0.1:
     resolution: {integrity: sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==}
@@ -1759,8 +1857,8 @@ packages:
     resolution: {integrity: sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==}
     engines: {node: ^10.12.0 || >=12.0.0}
 
-  flatted@3.3.3:
-    resolution: {integrity: sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==}
+  flatted@3.4.2:
+    resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
   for-each@0.3.5:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
@@ -2073,6 +2171,10 @@ packages:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
 
+  js-yaml@4.2.0:
+    resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
+    hasBin: true
+
   jsesc@3.1.0:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
     engines: {node: '>=6'}
@@ -2156,24 +2258,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.30.2:
     resolution: {integrity: sha512-5Vh9dGeblpTxWHpOx8iauV02popZDsCYMPIgiuw97OJ5uaDsL86cnqSFs5LZkG3ghHoX5isLgWzMs+eD1YzrnA==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.30.2:
     resolution: {integrity: sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.30.2:
     resolution: {integrity: sha512-XJaLUUFXb6/QG2lGIW6aIk6jKdtjtcffUT0NKvIqhSBY3hh9Ch+1LCeH80dR9q9LBjG3ewbDjnumefsLsP6aiA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.30.2:
     resolution: {integrity: sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==}
@@ -2306,8 +2412,15 @@ packages:
   minimatch@3.1.3:
     resolution: {integrity: sha512-M2GCs7Vk83NxkUyQV1bkABc4yxgz9kILhHImZiBPAZ9ybuvCb0/H7lEl5XvIg3g+9d4eNotkZA5IWwYl0tibaA==}
 
+  minimatch@3.1.5:
+    resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
+
   minimatch@5.1.7:
     resolution: {integrity: sha512-FjiwU9HaHW6YB3H4a1sFudnv93lvydNjz2lmyUXR6IwKhGI+bgL3SOZrBGn6kvvX2pJvhEkGSGjyTHN47O4rqA==}
+    engines: {node: '>=10'}
+
+  minimatch@5.1.9:
+    resolution: {integrity: sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==}
     engines: {node: '>=10'}
 
   minimatch@9.0.6:
@@ -2397,6 +2510,10 @@ packages:
     resolution: {integrity: sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==}
     engines: {node: '>= 0.4'}
 
+  obug@2.1.2:
+    resolution: {integrity: sha512-AWGB9WFcRXOQs48Z/udjI5ZcZMHXwX8XPByNpOydgcGsDLIzjGizhoMWJyKAWze7AVW/2W1i+/gPX4YtKe5cyg==}
+    engines: {node: '>=12.20.0'}
+
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
@@ -2458,6 +2575,9 @@ packages:
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
   pbkdf2@3.1.5:
     resolution: {integrity: sha512-Q3CG/cYvCO1ye4QKkuH7EXxs3VC/rI1/trd+qX2+PolbaKG0H+bgcZzrTt96mMyRtejk+JMCiLUn3y29W8qmFQ==}
@@ -2748,6 +2868,9 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
@@ -2782,9 +2905,15 @@ packages:
   sprintf-js@1.1.3:
     resolution: {integrity: sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
   stat-mode@1.0.0:
     resolution: {integrity: sha512-jH9EhtKIjuXZ2cWxmXS8ZP80XyC3iasQxMDV8jzhNJpfDb7VbQLVW4Wvsxz9QZvzV+G4YoSfBUVKDOyxLzi/sg==}
     engines: {node: '>= 6'}
+
+  std-env@4.1.0:
+    resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
   stream-browserify@3.0.0:
     resolution: {integrity: sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA==}
@@ -2874,9 +3003,20 @@ packages:
     resolution: {integrity: sha512-9phl76Cqm6FhSX9Xe1ZUAMLtm1BLkKj2Qd5ApyWkXzsMRaA7dgr81kf4wJmQf/hAvg8EEyJxDo3du/0KlhPiKQ==}
     engines: {node: '>=0.6.0'}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.2.4:
+    resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
+    engines: {node: '>=18'}
+
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
 
   tmp-promise@3.0.3:
     resolution: {integrity: sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ==}
@@ -3025,6 +3165,47 @@ packages:
       yaml:
         optional: true
 
+  vitest@4.1.8:
+    resolution: {integrity: sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.8
+      '@vitest/browser-preview': 4.1.8
+      '@vitest/browser-webdriverio': 4.1.8
+      '@vitest/coverage-istanbul': 4.1.8
+      '@vitest/coverage-v8': 4.1.8
+      '@vitest/ui': 4.1.8
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   vm-browserify@1.1.2:
     resolution: {integrity: sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==}
 
@@ -3038,6 +3219,11 @@ packages:
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   word-wrap@1.2.5:
@@ -3483,14 +3669,14 @@ snapshots:
 
   '@eslint/eslintrc@2.1.4':
     dependencies:
-      ajv: 6.14.0
+      ajv: 6.15.0
       debug: 4.4.3
       espree: 9.6.1
       globals: 13.24.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 4.1.1
-      minimatch: 3.1.3
+      js-yaml: 4.2.0
+      minimatch: 3.1.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
       - supports-color
@@ -3501,7 +3687,7 @@ snapshots:
     dependencies:
       '@humanwhocodes/object-schema': 2.0.3
       debug: 4.4.3
-      minimatch: 3.1.3
+      minimatch: 3.1.5
     transitivePeerDependencies:
       - supports-color
 
@@ -3540,6 +3726,10 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@kyc-rip/stealth-engines@git+https://github.com/KYC-rip/stealth-engines.git#51679521a597a4e3a1e460a133c936ff9b2ddd7c(ethers@6.16.0)':
+    dependencies:
+      ethers: 6.16.0
 
   '@malept/cross-spawn-promise@1.1.1':
     dependencies:
@@ -3672,6 +3862,8 @@ snapshots:
 
   '@sindresorhus/is@4.6.0': {}
 
+  '@standard-schema/spec@1.1.0': {}
+
   '@szmarczak/http-timer@4.0.6':
     dependencies:
       defer-to-connect: 2.0.1
@@ -3774,9 +3966,16 @@ snapshots:
       '@types/node': 25.2.3
       '@types/responselike': 1.0.3
 
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
   '@types/debug@4.1.12':
     dependencies:
       '@types/ms': 2.1.0
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/estree@1.0.8': {}
 
@@ -3918,7 +4117,7 @@ snapshots:
       '@typescript-eslint/types': 7.18.0
       eslint-visitor-keys: 3.4.3
 
-  '@ungap/structured-clone@1.3.0': {}
+  '@ungap/structured-clone@1.3.1': {}
 
   '@vitejs/plugin-react@4.7.0(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2))':
     dependencies:
@@ -3931,6 +4130,47 @@ snapshots:
       vite: 7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)
     transitivePeerDependencies:
       - supports-color
+
+  '@vitest/expect@4.1.8':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.8
+      '@vitest/utils': 4.1.8
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.8(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2))':
+    dependencies:
+      '@vitest/spy': 4.1.8
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)
+
+  '@vitest/pretty-format@4.1.8':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.8':
+    dependencies:
+      '@vitest/utils': 4.1.8
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.8':
+    dependencies:
+      '@vitest/pretty-format': 4.1.8
+      '@vitest/utils': 4.1.8
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.8': {}
+
+  '@vitest/utils@4.1.8':
+    dependencies:
+      '@vitest/pretty-format': 4.1.8
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
 
   '@xmldom/xmldom@0.8.11': {}
 
@@ -3957,6 +4197,13 @@ snapshots:
       ajv: 6.14.0
 
   ajv@6.14.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-json-stable-stringify: 2.1.0
+      json-schema-traverse: 0.4.1
+      uri-js: 4.4.1
+
+  ajv@6.15.0:
     dependencies:
       fast-deep-equal: 3.1.3
       fast-json-stable-stringify: 2.1.0
@@ -4073,6 +4320,8 @@ snapshots:
       object.assign: 4.1.7
       util: 0.12.5
 
+  assertion-error@2.0.1: {}
+
   astral-regex@2.0.0:
     optional: true
 
@@ -4134,7 +4383,16 @@ snapshots:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
+  brace-expansion@1.1.15:
+    dependencies:
+      balanced-match: 1.0.2
+      concat-map: 0.0.1
+
   brace-expansion@2.0.2:
+    dependencies:
+      balanced-match: 1.0.2
+
+  brace-expansion@2.1.1:
     dependencies:
       balanced-match: 1.0.2
 
@@ -4281,6 +4539,8 @@ snapshots:
   callsites@3.1.0: {}
 
   caniuse-lite@1.0.30001774: {}
+
+  chai@6.2.2: {}
 
   chalk@4.1.2:
     dependencies:
@@ -4635,6 +4895,8 @@ snapshots:
 
   es-errors@1.3.0: {}
 
+  es-module-lexer@2.1.0: {}
+
   es-object-atoms@1.1.1:
     dependencies:
       es-errors: 1.3.0
@@ -4740,8 +5002,8 @@ snapshots:
       '@humanwhocodes/config-array': 0.13.0
       '@humanwhocodes/module-importer': 1.0.1
       '@nodelib/fs.walk': 1.2.8
-      '@ungap/structured-clone': 1.3.0
-      ajv: 6.14.0
+      '@ungap/structured-clone': 1.3.1
+      ajv: 6.15.0
       chalk: 4.1.2
       cross-spawn: 7.0.6
       debug: 4.4.3
@@ -4762,11 +5024,11 @@ snapshots:
       imurmurhash: 0.1.4
       is-glob: 4.0.3
       is-path-inside: 3.0.3
-      js-yaml: 4.1.1
+      js-yaml: 4.2.0
       json-stable-stringify-without-jsonify: 1.0.1
       levn: 0.4.1
       lodash.merge: 4.6.2
-      minimatch: 3.1.3
+      minimatch: 3.1.5
       natural-compare: 1.4.0
       optionator: 0.9.4
       strip-ansi: 6.0.1
@@ -4792,6 +5054,10 @@ snapshots:
 
   estree-walker@2.0.2: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
   esutils@2.0.3: {}
 
   ethers@6.16.0:
@@ -4813,6 +5079,8 @@ snapshots:
     dependencies:
       md5.js: 1.3.5
       safe-buffer: 5.2.1
+
+  expect-type@1.3.0: {}
 
   extract-zip@2.0.1:
     dependencies:
@@ -4878,11 +5146,11 @@ snapshots:
 
   flat-cache@3.2.0:
     dependencies:
-      flatted: 3.3.3
+      flatted: 3.4.2
       keyv: 4.5.4
       rimraf: 3.0.2
 
-  flatted@3.3.3: {}
+  flatted@3.4.2: {}
 
   for-each@0.3.5:
     dependencies:
@@ -5229,6 +5497,10 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
+  js-yaml@4.2.0:
+    dependencies:
+      argparse: 2.0.1
+
   jsesc@3.1.0: {}
 
   json-buffer@3.0.1: {}
@@ -5417,9 +5689,17 @@ snapshots:
     dependencies:
       brace-expansion: 1.1.12
 
+  minimatch@3.1.5:
+    dependencies:
+      brace-expansion: 1.1.15
+
   minimatch@5.1.7:
     dependencies:
       brace-expansion: 2.0.2
+
+  minimatch@5.1.9:
+    dependencies:
+      brace-expansion: 2.1.1
 
   minimatch@9.0.6:
     dependencies:
@@ -5517,6 +5797,8 @@ snapshots:
       has-symbols: 1.1.0
       object-keys: 1.1.1
 
+  obug@2.1.2: {}
+
   once@1.4.0:
     dependencies:
       wrappy: 1.0.2
@@ -5574,6 +5856,8 @@ snapshots:
       minipass: 7.1.3
 
   path-type@4.0.0: {}
+
+  pathe@2.0.3: {}
 
   pbkdf2@3.1.5:
     dependencies:
@@ -5731,7 +6015,7 @@ snapshots:
 
   readdir-glob@1.1.3:
     dependencies:
-      minimatch: 5.1.7
+      minimatch: 5.1.9
 
   require-directory@2.1.1: {}
 
@@ -5896,6 +6180,8 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
   signal-exit@4.1.0: {}
 
   simple-update-notifier@2.0.0:
@@ -5926,7 +6212,11 @@ snapshots:
   sprintf-js@1.1.3:
     optional: true
 
+  stackback@0.0.2: {}
+
   stat-mode@1.0.0: {}
+
+  std-env@4.1.0: {}
 
   stream-browserify@3.0.0:
     dependencies:
@@ -6034,10 +6324,16 @@ snapshots:
     dependencies:
       setimmediate: 1.0.5
 
+  tinybench@2.9.0: {}
+
+  tinyexec@1.2.4: {}
+
   tinyglobby@0.2.15:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
+
+  tinyrainbow@3.1.0: {}
 
   tmp-promise@3.0.3:
     dependencies:
@@ -6156,6 +6452,33 @@ snapshots:
       jiti: 2.6.1
       lightningcss: 1.30.2
 
+  vitest@4.1.8(@types/node@25.2.3)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)):
+    dependencies:
+      '@vitest/expect': 4.1.8
+      '@vitest/mocker': 4.1.8(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2))
+      '@vitest/pretty-format': 4.1.8
+      '@vitest/runner': 4.1.8
+      '@vitest/snapshot': 4.1.8
+      '@vitest/spy': 4.1.8
+      '@vitest/utils': 4.1.8
+      es-module-lexer: 2.1.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.2
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.1.0
+      vite: 7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 25.2.3
+    transitivePeerDependencies:
+      - msw
+
   vm-browserify@1.1.2: {}
 
   when-exit@2.1.5: {}
@@ -6173,6 +6496,11 @@ snapshots:
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   word-wrap@1.2.5: {}
 

--- a/src/main/handlers/VigilHandler.ts
+++ b/src/main/handlers/VigilHandler.ts
@@ -1,0 +1,96 @@
+// src/main/handlers/VigilHandler.ts
+import { ipcMain } from 'electron';
+
+/**
+ * Persistence for the Vigil feature:
+ *  - strike-wallet key blobs (AES-GCM ciphertext produced in the renderer;
+ *    opaque to the main process — never plaintext key material)
+ *  - armed/executing session snapshots (config only, no key material)
+ *
+ * NOTE: strike-key blobs are intentionally NOT deleted when an identity is
+ * destroyed — an encrypted blob is the last recovery path for any funds left
+ * on the burner address.
+ */
+
+const ID_RE = /^[A-Za-z0-9_-]{1,64}$/;
+const B64_RE = /^[A-Za-z0-9+/]+={0,2}$/;
+const MAX_SESSION_BYTES = 16 * 1024;
+
+const KEYS_BUCKET = 'vigil_strike_keys';
+const SESSIONS_BUCKET = 'vigil_sessions';
+
+export const VIGIL_SESSION_VERSION = 1;
+
+function isValidId(id: unknown): id is string {
+  return typeof id === 'string' && ID_RE.test(id);
+}
+
+function isValidKeyBlob(blob: any): boolean {
+  return !!blob
+    && typeof blob === 'object'
+    && blob.v === 1
+    && typeof blob.salt === 'string' && blob.salt.length <= 64 && B64_RE.test(blob.salt)
+    && typeof blob.iv === 'string' && blob.iv.length <= 64 && B64_RE.test(blob.iv)
+    && typeof blob.ct === 'string' && blob.ct.length <= 4096 && B64_RE.test(blob.ct);
+}
+
+function isValidSession(session: any): { ok: boolean; error?: string } {
+  if (!session || typeof session !== 'object') return { ok: false, error: 'Session must be an object' };
+  if (session.version !== VIGIL_SESSION_VERSION) return { ok: false, error: `Unsupported session version ${session.version}` };
+  if (!['SNIPE', 'EJECT'].includes(session.mode)) return { ok: false, error: 'Invalid mode' };
+  if (!['ARMED', 'EXECUTING', 'POLLING'].includes(session.phase)) return { ok: false, error: 'Invalid phase' };
+  const json = JSON.stringify(session);
+  if (json.length > MAX_SESSION_BYTES) return { ok: false, error: 'Session too large' };
+  // Defense in depth: sessions must never carry key material
+  if (/privateKey|mnemonic|seed/i.test(json)) return { ok: false, error: 'Session must not contain key material' };
+  return { ok: true };
+}
+
+export function registerVigilHandlers(store: any) {
+  ipcMain.handle('vigil-save-strike-key', (_, identityId: string, blob: any) => {
+    if (!isValidId(identityId)) return { success: false, error: 'Invalid identity id' };
+    if (!isValidKeyBlob(blob)) return { success: false, error: 'Invalid key blob' };
+    const keys = store.get(KEYS_BUCKET) || {};
+    keys[identityId] = blob;
+    store.set(KEYS_BUCKET, keys);
+    return { success: true };
+  });
+
+  ipcMain.handle('vigil-get-strike-key', (_, identityId: string) => {
+    if (!isValidId(identityId)) return null;
+    const keys = store.get(KEYS_BUCKET) || {};
+    return keys[identityId] || null;
+  });
+
+  ipcMain.handle('vigil-delete-strike-key', (_, identityId: string) => {
+    if (!isValidId(identityId)) return { success: false, error: 'Invalid identity id' };
+    const keys = store.get(KEYS_BUCKET) || {};
+    delete keys[identityId];
+    store.set(KEYS_BUCKET, keys);
+    return { success: true };
+  });
+
+  ipcMain.handle('vigil-save-session', (_, identityId: string, session: any) => {
+    if (!isValidId(identityId)) return { success: false, error: 'Invalid identity id' };
+    const check = isValidSession(session);
+    if (!check.ok) return { success: false, error: check.error };
+    const sessions = store.get(SESSIONS_BUCKET) || {};
+    sessions[identityId] = session;
+    store.set(SESSIONS_BUCKET, sessions);
+    return { success: true };
+  });
+
+  ipcMain.handle('vigil-get-session', (_, identityId: string) => {
+    if (!isValidId(identityId)) return null;
+    const sessions = store.get(SESSIONS_BUCKET) || {};
+    return sessions[identityId] || null;
+  });
+
+  ipcMain.handle('vigil-clear-session', (_, identityId: string) => {
+    if (!isValidId(identityId)) return { success: false, error: 'Invalid identity id' };
+    const sessions = store.get(SESSIONS_BUCKET) || {};
+    delete sessions[identityId];
+    store.set(SESSIONS_BUCKET, sessions);
+    return { success: true };
+  });
+}

--- a/src/main/handlers/VigilHandler.ts
+++ b/src/main/handlers/VigilHandler.ts
@@ -17,6 +17,7 @@ const B64_RE = /^[A-Za-z0-9+/]+={0,2}$/;
 const MAX_SESSION_BYTES = 16 * 1024;
 
 const KEYS_BUCKET = 'vigil_strike_keys';
+const RETIRED_BUCKET = 'vigil_strike_keys_retired';
 const SESSIONS_BUCKET = 'vigil_sessions';
 
 export const VIGIL_SESSION_VERSION = 1;
@@ -67,6 +68,23 @@ export function registerVigilHandlers(store: any) {
     const keys = store.get(KEYS_BUCKET) || {};
     delete keys[identityId];
     store.set(KEYS_BUCKET, keys);
+    return { success: true };
+  });
+
+  // Burner rotation: move the current blob to a retired archive instead of
+  // overwriting it. Retired blobs stay recoverable forever with the vault
+  // password — a mistaken rotation can never strand funds permanently.
+  ipcMain.handle('vigil-archive-strike-key', (_, identityId: string) => {
+    if (!isValidId(identityId)) return { success: false, error: 'Invalid identity id' };
+    const keys = store.get(KEYS_BUCKET) || {};
+    const blob = keys[identityId];
+    if (blob) {
+      const retired = store.get(RETIRED_BUCKET) || {};
+      retired[identityId] = [...(retired[identityId] || []), { ...blob, retiredAt: Date.now() }];
+      store.set(RETIRED_BUCKET, retired);
+      delete keys[identityId];
+      store.set(KEYS_BUCKET, keys);
+    }
     return { success: true };
   });
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -566,6 +566,29 @@ app.whenReady().then(async () => {
     }
   });
 
+  // Kraken's REST API blocks browser CORS, so the renderer cannot seed the
+  // vigil chart with history. The main process has no CORS and net.fetch
+  // rides the default session (Tor proxy when enabled).
+  ipcMain.handle('fetch-price-history', async (_, pair: string) => {
+    try {
+      if (typeof pair !== 'string' || !/^[A-Z0-9]{2,8}\/[A-Z0-9]{2,8}$/.test(pair)) {
+        return { success: false, error: 'Invalid pair' };
+      }
+      const restPair = pair.replace('/', '');
+      const res = await net.fetch(`https://api.kraken.com/0/public/OHLC?pair=${restPair}&interval=1`);
+      const data: any = await res.json();
+      if (data.error?.length) return { success: false, error: data.error.join(', ') };
+      const key = Object.keys(data.result || {}).find(k => k !== 'last');
+      if (!key) return { success: false, error: 'No OHLC data' };
+      // Candle: [time, open, high, low, close, vwap, volume, count] — keep closes
+      const points = (data.result[key] as any[]).map(c => ({ time: Number(c[0]), value: parseFloat(c[4]) }))
+        .filter(p => p.time > 0 && p.value > 0);
+      return { success: true, points };
+    } catch (e: any) {
+      return { success: false, error: e.message };
+    }
+  });
+
   ipcMain.handle('proxy-request', async (_, payload: { method: string; params: any }) => {
     try {
       const isDaemonMethod = ['get_fee_estimate', 'get_info', 'get_last_block_header'].includes(payload.method);

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -8,6 +8,7 @@ import { WalletManager } from './WalletManager';
 import { SyncWatcher } from './SyncWatcher';
 import { AppConfig } from './types';
 import { registerIdentityHandlers } from './handlers/IdentityHandler';
+import { registerVigilHandlers } from './handlers/VigilHandler';
 import { AgentGateway } from './AgentGateway';
 
 if (process.defaultApp) {
@@ -239,6 +240,7 @@ app.whenReady().then(async () => {
 
   // 🔌 Register the Identity/Vault Handlers
   registerIdentityHandlers(store);
+  registerVigilHandlers(store);
 
   agentGateway = new AgentGateway(mainWindow, store);
   if (store.get('agent_config.enabled')) {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -48,6 +48,7 @@ const api = {
   vigilSaveStrikeKey: (identityId: string, blob: any) => ipcRenderer.invoke('vigil-save-strike-key', identityId, blob),
   vigilGetStrikeKey: (identityId: string) => ipcRenderer.invoke('vigil-get-strike-key', identityId),
   vigilDeleteStrikeKey: (identityId: string) => ipcRenderer.invoke('vigil-delete-strike-key', identityId),
+  vigilArchiveStrikeKey: (identityId: string) => ipcRenderer.invoke('vigil-archive-strike-key', identityId),
   vigilSaveSession: (identityId: string, session: any) => ipcRenderer.invoke('vigil-save-session', identityId, session),
   vigilGetSession: (identityId: string) => ipcRenderer.invoke('vigil-get-session', identityId),
   vigilClearSession: (identityId: string) => ipcRenderer.invoke('vigil-clear-session', identityId),

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -42,6 +42,7 @@ const api = {
     return () => ipcRenderer.removeListener('deep-link', handler);
   },
   proxyRequest: (payload: any) => ipcRenderer.invoke('proxy-request', payload),
+  fetchPriceHistory: (pair: string) => ipcRenderer.invoke('fetch-price-history', pair),
 
   // Vigil strike-wallet persistence (encrypted blobs + session snapshots)
   vigilSaveStrikeKey: (identityId: string, blob: any) => ipcRenderer.invoke('vigil-save-strike-key', identityId, blob),

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -43,6 +43,14 @@ const api = {
   },
   proxyRequest: (payload: any) => ipcRenderer.invoke('proxy-request', payload),
 
+  // Vigil strike-wallet persistence (encrypted blobs + session snapshots)
+  vigilSaveStrikeKey: (identityId: string, blob: any) => ipcRenderer.invoke('vigil-save-strike-key', identityId, blob),
+  vigilGetStrikeKey: (identityId: string) => ipcRenderer.invoke('vigil-get-strike-key', identityId),
+  vigilDeleteStrikeKey: (identityId: string) => ipcRenderer.invoke('vigil-delete-strike-key', identityId),
+  vigilSaveSession: (identityId: string, session: any) => ipcRenderer.invoke('vigil-save-session', identityId, session),
+  vigilGetSession: (identityId: string) => ipcRenderer.invoke('vigil-get-session', identityId),
+  vigilClearSession: (identityId: string) => ipcRenderer.invoke('vigil-clear-session', identityId),
+
   getAppInfo: () => ipcRenderer.invoke('get-app-info'),
   openPath: (targetPath: string) => ipcRenderer.invoke('open-path', targetPath),
   openExternal: (url: string, options?: { width?: number; height?: number }) => ipcRenderer.invoke('open-external', url, options),

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -14,6 +14,7 @@ import { ExchangeView } from './components/ExchangeView';
 import { VigilView } from './components/VigilView';
 import { XMR402Modal } from './components/common/XMR402Modal';
 import { VaultProvider } from './contexts/VaultContext';
+import { VigilProvider, useVigil } from './contexts/VigilContext';
 
 const SkinOverlay = ({ config }: { config: any }) => {
   if (!config?.skin_background) return null;
@@ -59,6 +60,13 @@ function MainApp() {
 
   const [showScanlines, setShowScanlines] = useState(resolvedTheme === 'dark');
   const [autoLockMinutes, setAutoLockMinutes] = useState(0);
+  const vigil = useVigil();
+  const vigilArmed = vigil.state !== 'IDLE' && vigil.state !== 'COMPLETED' && vigil.state !== 'ERROR';
+  const vigilArmedModeRef = useRef<'SNIPE' | 'EJECT' | null>(null);
+  useEffect(() => {
+    vigilArmedModeRef.current = vigilArmed ? (vigil.activeSession?.mode ?? null) : null;
+  }, [vigilArmed, vigil.activeSession]);
+
   const [uplink, setUplink] = useState<string>('SCANNING...');
   const [uplinkUrl, setUplinkUrl] = useState<string>('');
   const [sessionStartTime] = useState(Date.now());
@@ -114,6 +122,10 @@ function MainApp() {
     if (isLocked) return;
     const checkLock = setInterval(() => {
       if (autoLockMinutes <= 0) return;
+      // An armed EJECT needs the open wallet to dispatch on trigger — treat
+      // it as activity and hold the auto-lock. SNIPE runs fine while locked,
+      // so it does not inhibit. Manual lock always wins.
+      if (vigilArmedModeRef.current === 'EJECT') return;
       const now = Date.now();
       const elapsedMs = now - lastActivityRef.current;
       if (elapsedMs > autoLockMinutes * 60 * 1000) {
@@ -279,6 +291,13 @@ function MainApp() {
     return (
       <div className="relative min-h-screen bg-xmr-base text-xmr-green font-mono overflow-hidden">
         <SkinOverlay config={appConfig} />
+        {vigilArmed && (
+          <div className="fixed top-4 left-1/2 -translate-x-1/2 z-50 px-3 py-1.5 rounded-sm border border-xmr-ghost/50 bg-xmr-ghost/10 text-xmr-ghost text-[10px] font-black uppercase tracking-widest flex items-center gap-2 animate-pulse">
+            <span className="w-1.5 h-1.5 rounded-full bg-xmr-ghost" />
+            VIGIL ARMED — {vigil.activeSession?.mode || vigil.state}
+            {vigil.state === 'PAUSED_LOCKED' && ' · UNLOCK TO DISPATCH'}
+          </div>
+        )}
         <div className="relative z-10 w-full h-full">
           <AuthView
             onUnlock={unlock}
@@ -616,7 +635,11 @@ function MainApp() {
 export default function App() {
   return (
     <VaultProvider>
-      <MainApp />
+      {/* VigilProvider sits ABOVE the lock gate inside MainApp: an armed
+          vigil survives lock/unlock and dies only with the process. */}
+      <VigilProvider>
+        <MainApp />
+      </VigilProvider>
     </VaultProvider>
   );
 }

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -61,11 +61,10 @@ function MainApp() {
   const [showScanlines, setShowScanlines] = useState(resolvedTheme === 'dark');
   const [autoLockMinutes, setAutoLockMinutes] = useState(0);
   const vigil = useVigil();
+  // Auto-lock is never inhibited anymore: an armed EJECT keeps the wallet
+  // hot behind the locked UI (see vigilHotWallet), which is strictly safer
+  // than keeping the whole app unlocked.
   const vigilArmed = vigil.state !== 'IDLE' && vigil.state !== 'COMPLETED' && vigil.state !== 'ERROR';
-  const vigilArmedModeRef = useRef<'SNIPE' | 'EJECT' | null>(null);
-  useEffect(() => {
-    vigilArmedModeRef.current = vigilArmed ? (vigil.activeSession?.mode ?? null) : null;
-  }, [vigilArmed, vigil.activeSession]);
 
   const [uplink, setUplink] = useState<string>('SCANNING...');
   const [uplinkUrl, setUplinkUrl] = useState<string>('');
@@ -122,10 +121,6 @@ function MainApp() {
     if (isLocked) return;
     const checkLock = setInterval(() => {
       if (autoLockMinutes <= 0) return;
-      // An armed EJECT needs the open wallet to dispatch on trigger — treat
-      // it as activity and hold the auto-lock. SNIPE runs fine while locked,
-      // so it does not inhibit. Manual lock always wins.
-      if (vigilArmedModeRef.current === 'EJECT') return;
       const now = Date.now();
       const elapsedMs = now - lastActivityRef.current;
       if (elapsedMs > autoLockMinutes * 60 * 1000) {

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -391,7 +391,7 @@ function MainApp() {
 
           <NavGroup label="Exchange" groupKey="exchange">
             <NavButton id="exchange" label="Exchange" icon={ArrowDown} />
-            {!isPackaged && <NavButton id="vigil" label="Vigil / Limit" icon={Crosshair} />}
+            <NavButton id="vigil" label="Vigil / Limit" icon={Crosshair} />
           </NavGroup>
 
           <NavGroup label="Tools" groupKey="tools">
@@ -507,7 +507,7 @@ function MainApp() {
               <div className={view === 'home' ? 'block' : 'hidden'}><HomeView setView={setView} stats={stats} loading={statsLoading} /></div>
                 <div className={view === 'vault' ? 'block' : 'hidden'}><VaultView setView={setView} vault={vault} handleBurn={() => purgeIdentity(activeId)} appConfig={appConfig} /></div>
                 <div className={view === 'exchange' ? 'block' : 'hidden'}><ExchangeView localXmrAddress={address} /></div>
-                {!isPackaged && <div className={view === 'vigil' ? 'block' : 'hidden'}><VigilView localXmrAddress={address} /></div>}
+                <div className={view === 'vigil' ? 'block' : 'hidden'}><VigilView localXmrAddress={address} /></div>
 
               <div className={view === 'settings' ? 'block' : 'hidden'}><SettingsView /></div>
                 <div className={view === 'agent' ? 'block' : 'hidden'}><AgentTab /></div>

--- a/src/renderer/components/VigilView.tsx
+++ b/src/renderer/components/VigilView.tsx
@@ -51,6 +51,7 @@ export function VigilView({ localXmrAddress }: VigilViewProps) {
     exportStrikeKey,
     refreshStrike,
     refundStrike,
+    regenerateStrike,
   } = useVigil();
   const { createSubaddress, subaddresses } = useVault();
 
@@ -290,6 +291,7 @@ export function VigilView({ localXmrAddress }: VigilViewProps) {
                   onExportKey={exportStrikeKey}
                   onRefresh={refreshStrike}
                   onRefund={refundStrike}
+                  onRegenerate={(pwd) => regenerateStrike(pwd, localConfig.inputCurrency?.network || 'ERC20')}
                 />
               </div>
             )}

--- a/src/renderer/components/VigilView.tsx
+++ b/src/renderer/components/VigilView.tsx
@@ -291,7 +291,7 @@ export function VigilView({ localXmrAddress }: VigilViewProps) {
                   onExportKey={exportStrikeKey}
                   onRefresh={refreshStrike}
                   onRefund={refundStrike}
-                  onRegenerate={(pwd) => regenerateStrike(pwd, localConfig.inputCurrency?.network || 'ERC20')}
+                  onRegenerate={(pwd) => regenerateStrike(pwd, localConfig.inputCurrency?.network || 'ERC20', localConfig.inputCurrency?.ticker)}
                 />
               </div>
             )}

--- a/src/renderer/components/VigilView.tsx
+++ b/src/renderer/components/VigilView.tsx
@@ -1,10 +1,10 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { useState, useEffect } from 'react';
-import { Shield, Radio, Loader2, CheckCircle2, Copy, Check, AlertTriangle } from 'lucide-react';
+import { Shield, Radio, Loader2, CheckCircle2, Copy, Check, AlertTriangle, History, WifiOff, RotateCcw } from 'lucide-react';
 import { VigilConfig, type VigilConfigData } from './vigil/VigilConfig';
 import { VigilDashboard } from './vigil/VigilDashboard';
+import { StrikeWalletPanel } from './vigil/StrikeWalletPanel';
 import { Card } from './Card';
-import { AddressDisplay } from './common/AddressDisplay';
 import { CurrencySelector } from './CurrencySelector';
 import { useVigilEngine } from '../hooks/useVigilEngine';
 import { useVault } from '../hooks/useVault';
@@ -14,7 +14,7 @@ const notify = (msg: string) => console.log(`[Vigil] ${msg}`);
 
 // ─── Types ───
 
-type VigilState = 'IDLE' | 'WATCHING' | 'TRIGGERED' | 'EXECUTING' | 'COMPLETED' | 'ERROR';
+type VigilState = 'IDLE' | 'WATCHING' | 'TRIGGERED' | 'EXECUTING' | 'POLLING' | 'COMPLETED' | 'ERROR';
 
 interface VigilViewProps {
   localXmrAddress: string;
@@ -26,14 +26,29 @@ export function VigilView({ localXmrAddress }: VigilViewProps) {
   const {
     state,
     logs,
+    executionStatus,
+    progress,
     arm,
     abort,
+    retry,
     price,
     reset,
     wsConnected,
+    wsDegraded,
+    reconnectFeed,
     activeSession,
     completedTrade,
-    depositInfo,
+    pendingSession,
+    rearmPendingSession,
+    discardPendingSession,
+    strikeAddress,
+    strikeBalances,
+    strikeGas,
+    strikeCreated,
+    strikeUnlocked,
+    unlockStrike,
+    exportStrikeKey,
+    refreshStrike,
   } = useVigilEngine();
   const { createSubaddress, subaddresses } = useVault();
 
@@ -49,6 +64,7 @@ export function VigilView({ localXmrAddress }: VigilViewProps) {
     compliance: { kyc: 'ANY', log: 'ANY' },
   });
   const [copyFeedback, setCopyFeedback] = useState(false);
+  const [rearmError, setRearmError] = useState('');
 
   const isDanger = state === 'TRIGGERED' || state === 'EXECUTING';
   const vigilState = (state as VigilState) || 'IDLE';
@@ -120,13 +136,31 @@ export function VigilView({ localXmrAddress }: VigilViewProps) {
     setLocalConfig((prev) => ({ ...prev, triggerPrice: '' }));
   };
 
+  const handleRearm = async () => {
+    setRearmError('');
+    try {
+      await rearmPendingSession();
+    } catch (e: any) {
+      setRearmError(e.message || 'Re-arm failed');
+    }
+  };
+
+  // SNIPE arming requires a funded, unlocked strike wallet
+  const inputTicker = localConfig.inputCurrency?.ticker?.toUpperCase() || 'USDT';
+  const strikeTokenBalance = strikeBalances?.tokens?.[inputTicker];
+  const strikeFunded = strikeTokenBalance !== undefined
+    && parseFloat(localConfig.amount || '0') > 0
+    && parseFloat(strikeTokenBalance) >= parseFloat(localConfig.amount || '0');
+  const snipeBlocked = mode === 'SNIPE' && (!strikeUnlocked || !strikeFunded || !(strikeGas?.ok));
+
   // ─── Progress bar width ───
   const progressWidth = (() => {
     switch (vigilState) {
       case 'IDLE': return 'w-1/5';
-      case 'WATCHING': return 'w-3/5';
-      case 'TRIGGERED': return 'w-4/5';
-      case 'EXECUTING': return 'w-[90%]';
+      case 'WATCHING': return 'w-2/5';
+      case 'TRIGGERED': return 'w-3/5';
+      case 'EXECUTING': return 'w-4/5';
+      case 'POLLING': return 'w-[90%]';
       case 'COMPLETED': return 'w-full';
       case 'ERROR': return 'w-full';
       default: return 'w-0';
@@ -186,12 +220,77 @@ export function VigilView({ localXmrAddress }: VigilViewProps) {
         </div>
       </div>
 
+      {/* ─── Degraded feed banner ─── */}
+      {wsDegraded && vigilState === 'WATCHING' && (
+        <div className="px-4 py-2 bg-xmr-warning/10 border-b border-xmr-warning/30 flex items-center justify-between gap-3">
+          <div className="flex items-center gap-2 text-[10px] font-mono uppercase text-xmr-warning">
+            <WifiOff size={12} />
+            STALE FEED — price stream lost, triggers will not fire
+          </div>
+          <button
+            onClick={reconnectFeed}
+            className="px-3 py-1 border border-xmr-warning/50 text-xmr-warning text-[9px] font-black uppercase tracking-widest hover:bg-xmr-warning/10 transition-all"
+          >
+            Reconnect
+          </button>
+        </div>
+      )}
+
       {/* ─── Main Body ─── */}
       <div className="flex-1 w-full px-2 py-2 mx-auto transition-all duration-500 ease-in-out max-w-4xl">
 
         {/* IDLE: Configuration */}
         {vigilState === 'IDLE' && (
-          <div className="flex-1 p-1 relative flex flex-col items-center w-full">
+          <div className="flex-1 p-1 relative flex flex-col items-center w-full space-y-3">
+
+            {/* Persisted session recovery */}
+            {pendingSession && (
+              <div className="w-full max-w-3xl bg-xmr-ghost/5 border border-xmr-ghost/30 rounded-sm p-3 space-y-2 animate-in fade-in">
+                <div className="flex items-center gap-2 text-[10px] font-mono uppercase text-xmr-ghost">
+                  <History size={12} />
+                  {pendingSession.phase === 'POLLING'
+                    ? `Unfinished swap found (${pendingSession.tradeId})`
+                    : `Armed ${pendingSession.mode} session found from last run`}
+                </div>
+                <div className="text-[10px] text-xmr-dim font-mono">
+                  {pendingSession.triggers.map(t => `${t.id} ${t.operator} $${t.price}`).join(' | ')}
+                  {' — '}{pendingSession.config.amount} {pendingSession.config.inputCurrency?.ticker}
+                </div>
+                {pendingSession.mode === 'SNIPE' && pendingSession.phase !== 'POLLING' && !strikeUnlocked && (
+                  <div className="text-[10px] text-xmr-warning font-mono uppercase">Unlock the strike wallet below first</div>
+                )}
+                {rearmError && <div className="text-[10px] text-xmr-error font-mono uppercase">{rearmError}</div>}
+                <div className="flex gap-2">
+                  <button onClick={handleRearm}
+                    className="px-4 py-1.5 border border-xmr-ghost/50 text-xmr-ghost text-[9px] font-black uppercase tracking-widest hover:bg-xmr-ghost/10 transition-all">
+                    {pendingSession.phase === 'POLLING' ? 'Resume tracking' : 'Re-arm'}
+                  </button>
+                  <button onClick={discardPendingSession}
+                    className="px-4 py-1.5 border border-xmr-border text-xmr-dim text-[9px] font-black uppercase tracking-widest hover:text-xmr-error hover:border-xmr-error/50 transition-all">
+                    Discard
+                  </button>
+                </div>
+              </div>
+            )}
+
+            {/* SNIPE funding panel */}
+            {mode === 'SNIPE' && (
+              <div className="w-full max-w-3xl">
+                <StrikeWalletPanel
+                  unlocked={strikeUnlocked}
+                  address={strikeAddress}
+                  balances={strikeBalances}
+                  gas={strikeGas}
+                  created={strikeCreated}
+                  requiredAmount={localConfig.amount}
+                  requiredTicker={inputTicker}
+                  onUnlock={(pwd) => unlockStrike(pwd, localConfig.inputCurrency?.network || 'ERC20')}
+                  onExportKey={exportStrikeKey}
+                  onRefresh={refreshStrike}
+                />
+              </div>
+            )}
+
             <VigilConfig
               mode={mode}
               setMode={setMode}
@@ -199,6 +298,10 @@ export function VigilView({ localXmrAddress }: VigilViewProps) {
               setData={(data: any) => setLocalConfig((prev) => ({ ...prev, ...data }))}
               onArm={handleArm}
               currentPrice={price || 0}
+              armDisabled={snipeBlocked}
+              armDisabledReason={mode === 'SNIPE'
+                ? (!strikeUnlocked ? 'UNLOCK STRIKE WALLET' : !strikeFunded ? 'FUND STRIKE WALLET' : !(strikeGas?.ok) ? 'STRIKE WALLET NEEDS ETH FOR GAS' : undefined)
+                : undefined}
             />
           </div>
         )}
@@ -218,13 +321,18 @@ export function VigilView({ localXmrAddress }: VigilViewProps) {
           </div>
         )}
 
-        {/* EXECUTING: Spinner with logs */}
-        {vigilState === 'EXECUTING' && (
+        {/* EXECUTING / POLLING: Spinner with logs */}
+        {(vigilState === 'EXECUTING' || vigilState === 'POLLING') && (
           <div className="flex flex-col items-center justify-center min-h-[300px] space-y-6 animate-in fade-in">
-            <Loader2 size={48} className="text-xmr-error animate-spin" />
+            <Loader2 size={48} className={`animate-spin ${vigilState === 'POLLING' ? 'text-xmr-ghost' : 'text-xmr-error'}`} />
             <div className="text-xs font-mono text-current animate-pulse uppercase tracking-widest">
-              EXECUTING TRADE...
+              {vigilState === 'POLLING' ? (executionStatus || 'TRACKING SWAP...') : 'EXECUTING TRADE...'}
             </div>
+            {vigilState === 'POLLING' && (
+              <div className="w-full max-w-xs h-1 bg-xmr-border/30 rounded-full overflow-hidden">
+                <div className="h-full bg-xmr-ghost transition-all duration-700" style={{ width: `${progress}%` }} />
+              </div>
+            )}
 
             {/* Inline log stream */}
             <div className="w-full max-w-xl bg-xmr-base border border-xmr-border/20 rounded-sm p-3 max-h-[200px] overflow-y-auto font-mono text-[10px] space-y-0.5 custom-scrollbar">
@@ -285,40 +393,6 @@ export function VigilView({ localXmrAddress }: VigilViewProps) {
               </Card>
             )}
 
-            {/* SNIPE: Show deposit info */}
-            {mode === 'SNIPE' && depositInfo?.address && (
-              <Card className="p-6 w-full max-w-md bg-xmr-surface border-xmr-accent/20 space-y-4">
-                <div className="text-center space-y-2">
-                  <div className="text-[10px] text-xmr-accent font-mono uppercase tracking-widest">
-                    DEPOSIT REQUIRED
-                  </div>
-                  <p className="text-[9px] text-xmr-dim">
-                    Send the input amount to complete the swap
-                  </p>
-                </div>
-                <div className="p-3 bg-xmr-base border border-xmr-accent/20 rounded-sm space-y-2">
-                  <div className="flex justify-between text-[10px] font-mono uppercase">
-                    <span className="text-xmr-dim">Amount</span>
-                    <span className="text-xmr-accent font-bold">
-                      {depositInfo.amount} {depositInfo.ticker}
-                    </span>
-                  </div>
-                  <div className="flex items-center gap-2">
-                    <AddressDisplay
-                      address={depositInfo.address}
-                      className="text-[10px] text-xmr-green font-bold flex-grow"
-                    />
-                    <button
-                      onClick={() => handleCopy(depositInfo.address)}
-                      className="text-xmr-accent hover:scale-110 transition-transform shrink-0"
-                    >
-                      {copyFeedback ? <Check size={14} /> : <Copy size={14} />}
-                    </button>
-                  </div>
-                </div>
-              </Card>
-            )}
-
             <button
               onClick={handleReset}
               className="px-8 py-3 border border-xmr-green/50 text-xmr-green text-[10px] font-black uppercase tracking-[0.2em] hover:bg-xmr-green/10 transition-all"
@@ -337,7 +411,7 @@ export function VigilView({ localXmrAddress }: VigilViewProps) {
                 VIGIL ERROR
               </h3>
               <p className="text-[10px] text-xmr-dim uppercase tracking-[0.2em]">
-                An unexpected error occurred
+                {executionStatus || 'An unexpected error occurred'}
               </p>
             </div>
 
@@ -351,12 +425,20 @@ export function VigilView({ localXmrAddress }: VigilViewProps) {
               ))}
             </div>
 
-            <button
-              onClick={handleReset}
-              className="px-8 py-3 border border-xmr-error/50 text-xmr-error text-[10px] font-black uppercase tracking-[0.2em] hover:bg-xmr-error/10 transition-all"
-            >
-              RESET
-            </button>
+            <div className="flex gap-3">
+              <button
+                onClick={retry}
+                className="px-8 py-3 border border-xmr-warning/50 text-xmr-warning text-[10px] font-black uppercase tracking-[0.2em] hover:bg-xmr-warning/10 transition-all flex items-center gap-2"
+              >
+                <RotateCcw size={12} /> RETRY
+              </button>
+              <button
+                onClick={handleReset}
+                className="px-8 py-3 border border-xmr-error/50 text-xmr-error text-[10px] font-black uppercase tracking-[0.2em] hover:bg-xmr-error/10 transition-all"
+              >
+                RESET
+              </button>
+            </div>
           </div>
         )}
       </div>

--- a/src/renderer/components/VigilView.tsx
+++ b/src/renderer/components/VigilView.tsx
@@ -288,6 +288,7 @@ export function VigilView({ localXmrAddress }: VigilViewProps) {
                   onUnlock={(pwd) => unlockStrike(pwd, localConfig.inputCurrency?.network || 'ERC20')}
                   onExportKey={exportStrikeKey}
                   onRefresh={refreshStrike}
+                  onRefund={refundStrike}
                 />
               </div>
             )}

--- a/src/renderer/components/VigilView.tsx
+++ b/src/renderer/components/VigilView.tsx
@@ -50,6 +50,7 @@ export function VigilView({ localXmrAddress }: VigilViewProps) {
     unlockStrike,
     exportStrikeKey,
     refreshStrike,
+    refundStrike,
   } = useVigil();
   const { createSubaddress, subaddresses } = useVault();
 

--- a/src/renderer/components/VigilView.tsx
+++ b/src/renderer/components/VigilView.tsx
@@ -6,7 +6,7 @@ import { VigilDashboard } from './vigil/VigilDashboard';
 import { StrikeWalletPanel } from './vigil/StrikeWalletPanel';
 import { Card } from './Card';
 import { CurrencySelector } from './CurrencySelector';
-import { useVigilEngine } from '../hooks/useVigilEngine';
+import { useVigil } from '../contexts/VigilContext';
 import { useVault } from '../hooks/useVault';
 import { getOrCreateSubaddress } from '../services/subaddressService';
 // Lightweight notification (avoids react-hot-toast dependency)
@@ -35,6 +35,7 @@ export function VigilView({ localXmrAddress }: VigilViewProps) {
     reset,
     wsConnected,
     wsDegraded,
+    priceHistory,
     reconnectFeed,
     activeSession,
     completedTrade,
@@ -49,7 +50,7 @@ export function VigilView({ localXmrAddress }: VigilViewProps) {
     unlockStrike,
     exportStrikeKey,
     refreshStrike,
-  } = useVigilEngine();
+  } = useVigil();
   const { createSubaddress, subaddresses } = useVault();
 
   const [mode, setMode] = useState<'SNIPE' | 'EJECT'>('EJECT'); // Default EJECT for wallet app
@@ -317,6 +318,7 @@ export function VigilView({ localXmrAddress }: VigilViewProps) {
               realPrice={price}
               priceConnected={!!price && wsConnected !== false}
               externalLogs={logs}
+              priceHistory={priceHistory}
             />
           </div>
         )}

--- a/src/renderer/components/vigil/HeartbeatChart.tsx
+++ b/src/renderer/components/vigil/HeartbeatChart.tsx
@@ -1,0 +1,230 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { useEffect, useRef } from 'react';
+import { createChart, ColorType, type IChartApi, type ISeriesApi, type Time, AreaSeries, LineSeries } from 'lightweight-charts';
+
+interface Props {
+  triggerPrice: number;
+  stopPrice?: number;
+  mode: 'SNIPE' | 'EJECT';
+  isTriggered: boolean;
+  realPrice?: number | null;
+  /** Unix seconds, ascending, deduped — produced by the engine's tick buffer. */
+  priceHistory: { time: number; value: number }[];
+}
+
+export function HeartbeatChart({ triggerPrice, stopPrice, mode, isTriggered, realPrice, priceHistory }: Props) {
+  const chartContainerRef = useRef<HTMLDivElement>(null);
+  const chartRef = useRef<IChartApi | null>(null);
+
+  const seriesRef = useRef<ISeriesApi<"Area"> | null>(null);      // Price trend
+  const mainLineRef = useRef<ISeriesApi<"Line"> | null>(null);    // Main target line (green)
+  const stopLineRef = useRef<ISeriesApi<"Line"> | null>(null);    // Stop loss line (red)
+
+  // Last time written to the series (lightweight-charts requires non-decreasing times)
+  const lastTimeRef = useRef<number>(0);
+
+  // Theme: read CSS variables once per mount (desktop has no useTheme-driven chart colors)
+  const root = getComputedStyle(document.documentElement);
+  const textDim = root.getPropertyValue('--text-dim').trim();
+  const axisTextColor = textDim || '#64748b';
+
+  // Color configuration
+  const ghostColor = '#a855f7';
+  const dangerColor = '#ef4444';
+  const successColor = '#22c55e'; // xmr-green
+
+  const lineColor = isTriggered ? dangerColor : ghostColor;
+  const areaTopColor = isTriggered ? 'rgba(239, 68, 68, 0.4)' : 'rgba(168, 85, 247, 0.4)';
+  const areaBottomColor = isTriggered ? 'rgba(239, 68, 68, 0.0)' : 'rgba(168, 85, 247, 0.0)';
+
+  // --- A. Initialize chart ---
+  useEffect(() => {
+    if (!chartContainerRef.current) return;
+
+    // Create the Chart instance
+    const chart = createChart(chartContainerRef.current, {
+      layout: {
+        background: { type: ColorType.Solid, color: 'transparent' },
+        textColor: axisTextColor,
+        attributionLogo: false,
+      },
+      width: chartContainerRef.current.clientWidth,
+      height: chartContainerRef.current.clientHeight,
+      grid: {
+        vertLines: { visible: false },
+        horzLines: { visible: false },
+      },
+      rightPriceScale: { visible: false, borderVisible: false },
+      leftPriceScale: {
+        visible: true,
+        borderVisible: false,
+        ticksVisible: false,
+        scaleMargins: { top: 0.2, bottom: 0.2 } // Leave top/bottom margins so lines don't touch the edges
+      },
+      timeScale: {
+        visible: false,
+        borderVisible: false,
+        fixLeftEdge: false,
+        fixRightEdge: true,
+      },
+      crosshair: {
+        vertLine: { visible: false, labelVisible: false },
+        horzLine: { visible: false, labelVisible: false },
+      },
+      handleScroll: false,
+      handleScale: false,
+    });
+
+    // 1. Price trend (Area)
+    const series = chart.addSeries(AreaSeries, {
+      lineColor: lineColor,
+      topColor: areaTopColor,
+      bottomColor: areaBottomColor,
+      lineWidth: 2,
+      priceLineVisible: false,
+      crosshairMarkerVisible: true,
+      priceScaleId: 'left',
+    });
+
+    // 2. Main target line (Target - Green/Primary)
+    // Use a LineSeries to draw a horizontal line, which forces the chart scale to include this price
+    const mainSeries = chart.addSeries(LineSeries, {
+      color: 'transparent', // The line itself is transparent (we only look at the PriceLine)
+      lastValueVisible: false,
+      priceLineVisible: false,
+      crosshairMarkerVisible: false,
+      priceScaleId: 'left',
+    });
+
+    // Add the visible PriceLine
+    mainSeries.createPriceLine({
+      price: triggerPrice,
+      color: successColor,
+      lineWidth: 1,
+      lineStyle: 2, // Dashed
+      axisLabelVisible: true,
+      title: mode === 'SNIPE' ? 'BUY DIP' : 'TAKE PROFIT',
+    });
+
+    // 3. Stop / breakout line (Stop - Red)
+    // Only added when stopPrice exists and is > 0
+    let stopSeries: ISeriesApi<"Line"> | null = null;
+
+    if (stopPrice && stopPrice > 0) {
+      stopSeries = chart.addSeries(LineSeries, {
+        color: 'transparent',
+        lastValueVisible: false,
+        priceLineVisible: false,
+        crosshairMarkerVisible: false,
+        priceScaleId: 'left',
+      });
+
+      stopSeries.createPriceLine({
+        price: stopPrice,
+        color: dangerColor,
+        lineWidth: 1,
+        lineStyle: 1, // Dotted
+        axisLabelVisible: true,
+        title: mode === 'SNIPE' ? 'BREAKOUT' : 'STOP LOSS',
+      });
+    }
+
+    chartRef.current = chart;
+    seriesRef.current = series;
+    mainLineRef.current = mainSeries;
+    stopLineRef.current = stopSeries;
+    lastTimeRef.current = 0;
+
+    // Resize Observer
+    const resizeObserver = new ResizeObserver(entries => {
+      if (entries.length === 0 || !entries[0].target) return;
+      const newRect = entries[0].contentRect;
+      chart.applyOptions({ width: newRect.width, height: newRect.height });
+      chart.timeScale().fitContent();
+    });
+    resizeObserver.observe(chartContainerRef.current);
+
+    return () => {
+      resizeObserver.disconnect();
+      chart.remove();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [triggerPrice, stopPrice, mode]); // Dependencies include stopPrice
+
+  // --- B. Seed history data (from the engine's tick buffer, no REST fetch on desktop) ---
+  useEffect(() => {
+    if (seriesRef.current && priceHistory.length > 0) {
+      // 1. Seed price data
+      seriesRef.current.setData(priceHistory.map(d => ({ time: d.time as Time, value: d.value })));
+
+      // 2. Seed helper line data (to stretch the Y axis range)
+      // The hidden series must contain data so the chart auto-scales to include these prices
+      const dataPoints = priceHistory.map(d => ({ time: d.time as Time, value: triggerPrice }));
+      mainLineRef.current?.setData(dataPoints);
+
+      if (stopLineRef.current && stopPrice) {
+        const stopPoints = priceHistory.map(d => ({ time: d.time as Time, value: stopPrice }));
+        stopLineRef.current.setData(stopPoints);
+      }
+
+      lastTimeRef.current = priceHistory[priceHistory.length - 1].time;
+
+      chartRef.current?.timeScale().fitContent();
+    }
+  }, [priceHistory, triggerPrice, stopPrice]);
+
+  // --- C. Update live data ---
+  useEffect(() => {
+    if (seriesRef.current && realPrice) {
+      const now = Math.floor(Date.now() / 1000);
+
+      // Guard: lightweight-charts requires non-decreasing times
+      if (now <= lastTimeRef.current) return;
+      lastTimeRef.current = now;
+
+      // Update price
+      seriesRef.current.update({ time: now as Time, value: realPrice });
+
+      // Update helper lines (keep the straight lines extending)
+      mainLineRef.current?.update({ time: now as Time, value: triggerPrice });
+
+      if (stopLineRef.current && stopPrice) {
+        stopLineRef.current.update({ time: now as Time, value: stopPrice });
+      }
+    }
+  }, [realPrice, triggerPrice, stopPrice]);
+
+  // --- D. Dynamic style update ---
+  useEffect(() => {
+    if (seriesRef.current) {
+      seriesRef.current.applyOptions({
+        lineColor: lineColor,
+        topColor: areaTopColor,
+        bottomColor: areaBottomColor,
+      });
+    }
+  }, [isTriggered, lineColor, areaTopColor, areaBottomColor]);
+
+  return (
+    <div className="relative w-full h-full group">
+      {/* Chart Container */}
+      <div
+        ref={chartContainerRef}
+        className={`w-full h-full transition-opacity duration-1000 ease-in-out ${priceHistory.length === 0 ? 'opacity-0' : 'opacity-80'}`}
+      />
+
+      {/* Building-chart overlay while the tick buffer warms up */}
+      {priceHistory.length < 15 && (
+        <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
+          <span className="text-[9px] uppercase font-mono text-xmr-dim">LIVE FEED — building chart…</span>
+        </div>
+      )}
+
+      {/* Scanline effect */}
+      <div className="absolute inset-0 pointer-events-none overflow-hidden">
+        <div className="absolute inset-0 bg-gradient-to-b from-transparent via-xmr-ghost/20 dark:via-xmr-ghost/10 to-transparent h-[50%] animate-scan" />
+        <div className="absolute inset-0 shadow-0 dark:shadow-[inset_0_0_50px_rgba(0,0,0,0.5)]" />
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/components/vigil/HeartbeatChart.tsx
+++ b/src/renderer/components/vigil/HeartbeatChart.tsx
@@ -159,12 +159,23 @@ export function HeartbeatChart({ triggerPrice, stopPrice, mode, isTriggered, rea
       seriesRef.current.setData(priceHistory.map(d => ({ time: d.time as Time, value: d.value })));
 
       // 2. Seed helper line data (to stretch the Y axis range)
-      // The hidden series must contain data so the chart auto-scales to include these prices
-      const dataPoints = priceHistory.map(d => ({ time: d.time as Time, value: triggerPrice }));
+      // The hidden series must contain data so the chart auto-scales to
+      // include these prices — but ONLY when the target is within reach.
+      // Forcing a far-away target (e.g. +60%) into frame flattens the live
+      // price into a dead horizontal line; beyond the band we let the price
+      // action own the scale and the dashed line sits off-frame.
+      const lastValue = priceHistory[priceHistory.length - 1].value;
+      const inBand = (p: number) => lastValue > 0 && Math.abs(p - lastValue) / lastValue <= 0.15;
+
+      const dataPoints = inBand(triggerPrice)
+        ? priceHistory.map(d => ({ time: d.time as Time, value: triggerPrice }))
+        : [];
       mainLineRef.current?.setData(dataPoints);
 
       if (stopLineRef.current && stopPrice) {
-        const stopPoints = priceHistory.map(d => ({ time: d.time as Time, value: stopPrice }));
+        const stopPoints = inBand(stopPrice)
+          ? priceHistory.map(d => ({ time: d.time as Time, value: stopPrice }))
+          : [];
         stopLineRef.current.setData(stopPoints);
       }
 

--- a/src/renderer/components/vigil/HeartbeatChart.tsx
+++ b/src/renderer/components/vigil/HeartbeatChart.tsx
@@ -83,6 +83,22 @@ export function HeartbeatChart({ triggerPrice, stopPrice, mode, isTriggered, rea
       lineWidth: 2,
       priceLineVisible: false,
       lastValueVisible: false,
+      // Enforce a minimum visible range of ±0.25% around the mid so a quiet
+      // market reads as a calm line instead of full-height micro-noise, and
+      // genuinely flat stretches still get a sensible scale.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      autoscaleInfoProvider: (original: () => any) => {
+        const res = original();
+        if (res?.priceRange) {
+          const { minValue, maxValue } = res.priceRange;
+          const mid = (minValue + maxValue) / 2;
+          const minSpan = mid * 0.005;
+          if (maxValue - minValue < minSpan) {
+            return { ...res, priceRange: { minValue: mid - minSpan / 2, maxValue: mid + minSpan / 2 } };
+          }
+        }
+        return res;
+      },
       crosshairMarkerVisible: true,
       priceScaleId: 'left',
     });

--- a/src/renderer/components/vigil/HeartbeatChart.tsx
+++ b/src/renderer/components/vigil/HeartbeatChart.tsx
@@ -56,7 +56,7 @@ export function HeartbeatChart({ triggerPrice, stopPrice, mode, isTriggered, rea
       },
       rightPriceScale: { visible: false, borderVisible: false },
       leftPriceScale: {
-        visible: true,
+        visible: false,
         borderVisible: false,
         ticksVisible: false,
         scaleMargins: { top: 0.2, bottom: 0.2 } // Leave top/bottom margins so lines don't touch the edges
@@ -82,6 +82,7 @@ export function HeartbeatChart({ triggerPrice, stopPrice, mode, isTriggered, rea
       bottomColor: areaBottomColor,
       lineWidth: 2,
       priceLineVisible: false,
+      lastValueVisible: false,
       crosshairMarkerVisible: true,
       priceScaleId: 'left',
     });
@@ -102,7 +103,7 @@ export function HeartbeatChart({ triggerPrice, stopPrice, mode, isTriggered, rea
       color: successColor,
       lineWidth: 1,
       lineStyle: 2, // Dashed
-      axisLabelVisible: true,
+      axisLabelVisible: false,
       title: mode === 'SNIPE' ? 'BUY DIP' : 'TAKE PROFIT',
     });
 
@@ -124,7 +125,7 @@ export function HeartbeatChart({ triggerPrice, stopPrice, mode, isTriggered, rea
         color: dangerColor,
         lineWidth: 1,
         lineStyle: 1, // Dotted
-        axisLabelVisible: true,
+        axisLabelVisible: false,
         title: mode === 'SNIPE' ? 'BREAKOUT' : 'STOP LOSS',
       });
     }

--- a/src/renderer/components/vigil/HeartbeatChart.tsx
+++ b/src/renderer/components/vigil/HeartbeatChart.tsx
@@ -214,7 +214,7 @@ export function HeartbeatChart({ triggerPrice, stopPrice, mode, isTriggered, rea
       />
 
       {/* Building-chart overlay while the tick buffer warms up */}
-      {priceHistory.length < 15 && (
+      {priceHistory.length < 2 && (
         <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
           <span className="text-[9px] uppercase font-mono text-xmr-dim">LIVE FEED — building chart…</span>
         </div>

--- a/src/renderer/components/vigil/StrikeWalletPanel.tsx
+++ b/src/renderer/components/vigil/StrikeWalletPanel.tsx
@@ -16,6 +16,7 @@ interface Props {
   onExportKey: (vaultPassword: string) => Promise<string>;
   onRefresh: () => Promise<void>;
   onRefund: (toAddress: string, ticker?: string) => Promise<string>;
+  onRegenerate: (vaultPassword: string) => Promise<unknown>;
 }
 
 /**
@@ -25,7 +26,7 @@ interface Props {
 export function StrikeWalletPanel({
   unlocked, address, balances, gas, created,
   requiredAmount, requiredTicker,
-  onUnlock, onExportKey, onRefresh, onRefund,
+  onUnlock, onExportKey, onRefresh, onRefund, onRegenerate,
 }: Props) {
   const [password, setPassword] = useState('');
   const [busy, setBusy] = useState(false);
@@ -37,6 +38,8 @@ export function StrikeWalletPanel({
   const [sweepBusy, setSweepBusy] = useState(false);
   const [sweepResult, setSweepResult] = useState<string | null>(null);
   const [sweepError, setSweepError] = useState<string | null>(null);
+  const [showRotate, setShowRotate] = useState(false);
+  const [rotateError, setRotateError] = useState('');
   const [copied, setCopied] = useState(false);
 
   // Surface the backup prompt automatically right after key generation
@@ -89,6 +92,21 @@ export function StrikeWalletPanel({
       setSweepError(e.message || 'Sweep failed');
     } finally {
       setSweepBusy(false);
+    }
+  };
+
+  const handleRotate = async () => {
+    if (!password || busy) return;
+    setBusy(true);
+    setRotateError('');
+    try {
+      await onRegenerate(password);
+      setPassword('');
+      setShowRotate(false);
+    } catch (e) {
+      setRotateError((e as Error).message || 'Rotation failed');
+    } finally {
+      setBusy(false);
     }
   };
 
@@ -239,6 +257,37 @@ export function StrikeWalletPanel({
                 className="text-[9px] text-xmr-dim uppercase tracking-wider hover:text-xmr-accent transition-colors flex items-center gap-1">
                 <Send size={10} /> Sweep leftovers
               </button>
+              <button onClick={() => { setShowRotate(!showRotate); setRotateError(''); }}
+                className="text-[9px] text-xmr-dim uppercase tracking-wider hover:text-xmr-accent transition-colors flex items-center gap-1">
+                <RefreshCw size={10} /> New burner
+              </button>
+            </div>
+          )}
+
+          {/* Burner rotation: fresh address for forward privacy. The engine
+              refuses while funds remain (sweep first) or a vigil is armed. */}
+          {showRotate && (
+            <div className="border border-xmr-ghost/30 bg-xmr-ghost/5 rounded-sm p-2 space-y-2">
+              <p className="text-[9px] text-xmr-dim leading-relaxed uppercase font-mono">
+                Retires the current address (old key stays recoverable) and mints a fresh one.
+                Requires an empty burner — sweep leftovers first. Fund each burner from varied sources for best effect.
+              </p>
+              <div className="flex gap-2">
+                <input
+                  type="password"
+                  value={password}
+                  placeholder="Vault password"
+                  onChange={(e) => { setPassword(e.target.value); setRotateError(''); }}
+                  onKeyDown={(e) => e.key === 'Enter' && handleRotate()}
+                  className="flex-1 bg-xmr-base border border-xmr-border rounded-sm py-1.5 px-2 text-[10px] font-mono focus:outline-none focus:border-xmr-ghost"
+                />
+                <button onClick={handleRotate} disabled={!password || busy}
+                  className="px-3 py-1.5 border border-xmr-ghost/50 text-xmr-ghost rounded-sm text-[9px] font-black uppercase hover:bg-xmr-ghost/10 disabled:opacity-30 transition-all">
+                  {busy ? <Loader2 size={10} className="animate-spin" /> : 'Rotate'}
+                </button>
+                <button onClick={() => setShowRotate(false)} className="px-2 text-xmr-dim text-[9px] uppercase hover:text-current">Close</button>
+              </div>
+              {rotateError && <div className="text-[10px] text-xmr-error font-mono uppercase">{rotateError}</div>}
             </div>
           )}
 

--- a/src/renderer/components/vigil/StrikeWalletPanel.tsx
+++ b/src/renderer/components/vigil/StrikeWalletPanel.tsx
@@ -1,0 +1,214 @@
+import { useState, useEffect } from 'react';
+import { QRCodeSVG } from 'qrcode.react';
+import { Zap, Lock, Loader2, RefreshCw, Eye, EyeOff, Copy, Check, AlertTriangle } from 'lucide-react';
+import { AddressDisplay } from '../common/AddressDisplay';
+import type { StrikeBalances, GasCheck } from '../../services/strikeWallet';
+
+interface Props {
+  unlocked: boolean;
+  address: string;
+  balances: StrikeBalances | null;
+  gas: GasCheck | null;
+  created: boolean;
+  requiredAmount: string;
+  requiredTicker: string;
+  onUnlock: (vaultPassword: string) => Promise<unknown>;
+  onExportKey: (vaultPassword: string) => Promise<string>;
+  onRefresh: () => Promise<void>;
+}
+
+/**
+ * SNIPE funding panel: a dedicated EVM burner wallet the user pre-funds
+ * before arming. The engine auto-sends from it when the trigger fires.
+ */
+export function StrikeWalletPanel({
+  unlocked, address, balances, gas, created,
+  requiredAmount, requiredTicker,
+  onUnlock, onExportKey, onRefresh,
+}: Props) {
+  const [password, setPassword] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState('');
+  const [revealedKey, setRevealedKey] = useState<string | null>(null);
+  const [showExport, setShowExport] = useState(false);
+  const [copied, setCopied] = useState(false);
+
+  // Surface the backup prompt automatically right after key generation
+  useEffect(() => { if (created) setShowExport(true); }, [created]);
+
+  const handleUnlock = async () => {
+    if (!password || busy) return;
+    setBusy(true);
+    setError('');
+    try {
+      await onUnlock(password);
+      setPassword('');
+    } catch (e: any) {
+      setError(e.message || 'Unlock failed');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleExport = async () => {
+    if (!password || busy) return;
+    setBusy(true);
+    setError('');
+    try {
+      setRevealedKey(await onExportKey(password));
+      setPassword('');
+    } catch (e: any) {
+      setError(e.message || 'Export failed');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleCopy = (text: string) => {
+    navigator.clipboard.writeText(text);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  const tokenBalance = balances?.tokens?.[requiredTicker];
+  const funded = tokenBalance !== undefined && parseFloat(tokenBalance) >= parseFloat(requiredAmount || '0') && parseFloat(requiredAmount || '0') > 0;
+
+  return (
+    <div className="bg-xmr-base/30 border border-xmr-accent/30 rounded-sm p-3 space-y-3 animate-in fade-in">
+      <div className="flex justify-between items-center border-b border-xmr-border/30 pb-1.5">
+        <div className="flex items-center gap-2">
+          <div className="p-1 rounded-sm bg-xmr-accent/10 text-xmr-accent"><Zap size={12} /></div>
+          <span className="text-[10px] text-xmr-dim font-mono uppercase tracking-widest">Strike_Wallet (EVM Burner)</span>
+        </div>
+        {unlocked && (
+          <button onClick={() => onRefresh()} className="text-xmr-dim hover:text-xmr-accent transition-colors" title="Refresh balances">
+            <RefreshCw size={12} />
+          </button>
+        )}
+      </div>
+
+      {!unlocked ? (
+        <div className="space-y-2">
+          <p className="text-[10px] text-xmr-dim leading-relaxed">
+            SNIPE orders are funded from a dedicated burner wallet so the trigger can fire unattended.
+            Enter your vault password to load (or generate) this identity's strike key.
+          </p>
+          <div className="flex gap-2">
+            <input
+              type="password"
+              value={password}
+              placeholder="Vault password"
+              onChange={(e) => { setPassword(e.target.value); setError(''); }}
+              onKeyDown={(e) => e.key === 'Enter' && handleUnlock()}
+              className="flex-1 bg-xmr-base border border-xmr-border rounded-sm py-2 px-3 text-xs font-mono text-current focus:outline-none focus:border-xmr-accent transition-colors"
+            />
+            <button
+              onClick={handleUnlock}
+              disabled={!password || busy}
+              className="px-4 py-2 border border-xmr-accent/50 text-xmr-accent rounded-sm text-[10px] font-black uppercase tracking-widest hover:bg-xmr-accent/10 disabled:opacity-30 disabled:cursor-not-allowed transition-all flex items-center gap-1.5"
+            >
+              {busy ? <Loader2 size={12} className="animate-spin" /> : <Lock size={12} />}
+              Unlock
+            </button>
+          </div>
+          {error && <div className="text-[10px] text-xmr-error font-mono uppercase">{error}</div>}
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {/* Address + QR for pre-funding */}
+          <div className="flex gap-3 items-start">
+            <div className="bg-white p-1.5 rounded-sm shrink-0">
+              <QRCodeSVG value={address} size={72} />
+            </div>
+            <div className="flex-1 min-w-0 space-y-2">
+              <div>
+                <div className="text-[9px] text-xmr-dim font-mono uppercase tracking-widest mb-1">Fund this address before arming</div>
+                <div className="flex items-center gap-2">
+                  <AddressDisplay address={address} className="text-[10px] text-xmr-accent font-bold" />
+                  <button onClick={() => handleCopy(address)} className="text-xmr-dim hover:text-xmr-accent shrink-0 transition-colors">
+                    {copied ? <Check size={12} /> : <Copy size={12} />}
+                  </button>
+                </div>
+              </div>
+              <div className="grid grid-cols-2 gap-2 text-[10px] font-mono">
+                <div className="bg-black/30 rounded-sm px-2 py-1.5 border border-xmr-border/30">
+                  <span className="text-xmr-dim block text-[9px] uppercase">{requiredTicker || 'Token'}</span>
+                  <span className={funded ? 'text-xmr-green font-bold' : 'text-current'}>{tokenBalance ?? '—'}</span>
+                </div>
+                <div className="bg-black/30 rounded-sm px-2 py-1.5 border border-xmr-border/30">
+                  <span className="text-xmr-dim block text-[9px] uppercase">ETH (gas)</span>
+                  <span className={gas?.ok ? 'text-xmr-green font-bold' : 'text-current'}>{balances?.eth ?? '—'}</span>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          {/* Funding / gas warnings */}
+          {requiredAmount && !funded && (
+            <div className="flex items-center gap-2 text-[10px] text-xmr-warning font-mono uppercase">
+              <AlertTriangle size={12} className="shrink-0" />
+              Needs {requiredAmount} {requiredTicker} before arming
+            </div>
+          )}
+          {gas && !gas.ok && (
+            <div className="flex items-center gap-2 text-[10px] text-xmr-warning font-mono uppercase">
+              <AlertTriangle size={12} className="shrink-0" />
+              Short ~{gas.missingEth} ETH for gas
+            </div>
+          )}
+
+          {/* Key backup / export */}
+          {showExport && !revealedKey && (
+            <div className="border border-xmr-warning/30 bg-xmr-warning/5 rounded-sm p-2 space-y-2">
+              <p className="text-[10px] text-xmr-warning leading-relaxed font-mono uppercase">
+                {created ? 'New key generated — back it up now.' : 'Reveal strike key'}
+              </p>
+              <p className="text-[9px] text-xmr-dim leading-relaxed">
+                The key is recoverable only with your vault password. Export it if this wallet will hold meaningful funds.
+              </p>
+              <div className="flex gap-2">
+                <input
+                  type="password"
+                  value={password}
+                  placeholder="Vault password"
+                  onChange={(e) => { setPassword(e.target.value); setError(''); }}
+                  onKeyDown={(e) => e.key === 'Enter' && handleExport()}
+                  className="flex-1 bg-xmr-base border border-xmr-border rounded-sm py-1.5 px-2 text-[10px] font-mono focus:outline-none focus:border-xmr-warning"
+                />
+                <button onClick={handleExport} disabled={!password || busy}
+                  className="px-3 py-1.5 border border-xmr-warning/50 text-xmr-warning rounded-sm text-[9px] font-black uppercase hover:bg-xmr-warning/10 disabled:opacity-30 transition-all">
+                  {busy ? <Loader2 size={10} className="animate-spin" /> : 'Reveal'}
+                </button>
+                {!created && (
+                  <button onClick={() => setShowExport(false)} className="px-2 text-xmr-dim text-[9px] uppercase hover:text-current">Close</button>
+                )}
+              </div>
+              {error && <div className="text-[10px] text-xmr-error font-mono uppercase">{error}</div>}
+            </div>
+          )}
+          {revealedKey && (
+            <div className="border border-xmr-error/30 bg-xmr-error/5 rounded-sm p-2 space-y-1.5">
+              <div className="text-[9px] text-xmr-error font-mono uppercase font-black">Private key — anyone with this controls the funds</div>
+              <div className="flex items-center gap-2">
+                <code className="text-[9px] text-current break-all flex-1">{revealedKey}</code>
+                <button onClick={() => handleCopy(revealedKey)} className="text-xmr-dim hover:text-xmr-error shrink-0">
+                  {copied ? <Check size={12} /> : <Copy size={12} />}
+                </button>
+              </div>
+              <button onClick={() => { setRevealedKey(null); setShowExport(false); }}
+                className="text-[9px] text-xmr-dim uppercase hover:text-current flex items-center gap-1">
+                <EyeOff size={10} /> Hide
+              </button>
+            </div>
+          )}
+          {!showExport && !revealedKey && (
+            <button onClick={() => setShowExport(true)}
+              className="text-[9px] text-xmr-dim uppercase tracking-wider hover:text-xmr-accent transition-colors flex items-center gap-1">
+              <Eye size={10} /> Export / back up key
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/renderer/components/vigil/StrikeWalletPanel.tsx
+++ b/src/renderer/components/vigil/StrikeWalletPanel.tsx
@@ -39,6 +39,7 @@ export function StrikeWalletPanel({
   const [sweepResult, setSweepResult] = useState<string | null>(null);
   const [sweepError, setSweepError] = useState<string | null>(null);
   const [showRotate, setShowRotate] = useState(false);
+  const [rotateBusy, setRotateBusy] = useState(false);
   const [rotateError, setRotateError] = useState('');
   const [copied, setCopied] = useState(false);
 
@@ -96,17 +97,20 @@ export function StrikeWalletPanel({
   };
 
   const handleRotate = async () => {
-    if (!password || busy) return;
-    setBusy(true);
+    if (!password || rotateBusy) return;
+    setRotateBusy(true);
     setRotateError('');
     try {
+      // Close the rotate panel immediately on success so the auto-opened
+      // backup prompt (fresh key) is the only thing showing — the trailing
+      // balance refresh inside onRegenerate must not keep this spinning.
       await onRegenerate(password);
       setPassword('');
       setShowRotate(false);
     } catch (e) {
       setRotateError((e as Error).message || 'Rotation failed');
     } finally {
-      setBusy(false);
+      setRotateBusy(false);
     }
   };
 
@@ -281,9 +285,9 @@ export function StrikeWalletPanel({
                   onKeyDown={(e) => e.key === 'Enter' && handleRotate()}
                   className="flex-1 bg-xmr-base border border-xmr-border rounded-sm py-1.5 px-2 text-[10px] font-mono focus:outline-none focus:border-xmr-ghost"
                 />
-                <button onClick={handleRotate} disabled={!password || busy}
+                <button onClick={handleRotate} disabled={!password || rotateBusy}
                   className="px-3 py-1.5 border border-xmr-ghost/50 text-xmr-ghost rounded-sm text-[9px] font-black uppercase hover:bg-xmr-ghost/10 disabled:opacity-30 transition-all">
-                  {busy ? <Loader2 size={10} className="animate-spin" /> : 'Rotate'}
+                  {rotateBusy ? <Loader2 size={10} className="animate-spin" /> : 'Rotate'}
                 </button>
                 <button onClick={() => setShowRotate(false)} className="px-2 text-xmr-dim text-[9px] uppercase hover:text-current">Close</button>
               </div>

--- a/src/renderer/components/vigil/StrikeWalletPanel.tsx
+++ b/src/renderer/components/vigil/StrikeWalletPanel.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import { QRCodeSVG } from 'qrcode.react';
-import { Zap, Lock, Loader2, RefreshCw, Eye, EyeOff, Copy, Check, AlertTriangle } from 'lucide-react';
+import { Zap, Lock, Loader2, RefreshCw, Eye, EyeOff, Copy, Check, AlertTriangle, Send } from 'lucide-react';
 import { AddressDisplay } from '../common/AddressDisplay';
 import type { StrikeBalances, GasCheck } from '../../services/strikeWallet';
 
@@ -15,6 +15,7 @@ interface Props {
   onUnlock: (vaultPassword: string) => Promise<unknown>;
   onExportKey: (vaultPassword: string) => Promise<string>;
   onRefresh: () => Promise<void>;
+  onRefund: (toAddress: string, ticker?: string) => Promise<string>;
 }
 
 /**
@@ -24,13 +25,18 @@ interface Props {
 export function StrikeWalletPanel({
   unlocked, address, balances, gas, created,
   requiredAmount, requiredTicker,
-  onUnlock, onExportKey, onRefresh,
+  onUnlock, onExportKey, onRefresh, onRefund,
 }: Props) {
   const [password, setPassword] = useState('');
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState('');
   const [revealedKey, setRevealedKey] = useState<string | null>(null);
   const [showExport, setShowExport] = useState(false);
+  const [showSweep, setShowSweep] = useState(false);
+  const [sweepAddr, setSweepAddr] = useState('');
+  const [sweepBusy, setSweepBusy] = useState(false);
+  const [sweepResult, setSweepResult] = useState<string | null>(null);
+  const [sweepError, setSweepError] = useState<string | null>(null);
   const [copied, setCopied] = useState(false);
 
   // Surface the backup prompt automatically right after key generation
@@ -69,6 +75,20 @@ export function StrikeWalletPanel({
       setError(e.message || 'Export failed');
     } finally {
       setBusy(false);
+    }
+  };
+
+  const handleSweep = async () => {
+    if (sweepBusy || !/^0x[0-9a-fA-F]{40}$/.test(sweepAddr)) return;
+    setSweepBusy(true);
+    setSweepError(null);
+    try {
+      setSweepResult(await onRefund(sweepAddr, requiredTicker));
+      setSweepAddr('');
+    } catch (e: any) {
+      setSweepError(e.message || 'Sweep failed');
+    } finally {
+      setSweepBusy(false);
     }
   };
 
@@ -210,10 +230,49 @@ export function StrikeWalletPanel({
             </div>
           )}
           {!showExport && !revealedKey && (
-            <button onClick={() => setShowExport(true)}
-              className="text-[9px] text-xmr-dim uppercase tracking-wider hover:text-xmr-accent transition-colors flex items-center gap-1">
-              <Eye size={10} /> Export / back up key
-            </button>
+            <div className="flex items-center gap-4">
+              <button onClick={() => setShowExport(true)}
+                className="text-[9px] text-xmr-dim uppercase tracking-wider hover:text-xmr-accent transition-colors flex items-center gap-1">
+                <Eye size={10} /> Export / back up key
+              </button>
+              <button onClick={() => { setShowSweep(!showSweep); setSweepResult(null); setSweepError(null); }}
+                className="text-[9px] text-xmr-dim uppercase tracking-wider hover:text-xmr-accent transition-colors flex items-center gap-1">
+                <Send size={10} /> Sweep leftovers
+              </button>
+            </div>
+          )}
+
+          {/* Sweep leftovers: token balance + remaining ETH minus gas */}
+          {showSweep && !sweepResult && (
+            <div className="border border-xmr-border/40 bg-black/20 rounded-sm p-2 space-y-2">
+              <p className="text-[9px] text-xmr-dim leading-relaxed uppercase font-mono">
+                Sweeps {requiredTicker || 'token'} + remaining ETH (minus gas) to an address you control
+              </p>
+              <div className="flex gap-2">
+                <input
+                  type="text"
+                  value={sweepAddr}
+                  placeholder="0x… destination"
+                  onChange={(e) => { setSweepAddr(e.target.value.trim()); setSweepError(null); }}
+                  onKeyDown={(e) => e.key === 'Enter' && handleSweep()}
+                  className="flex-1 bg-xmr-base border border-xmr-border rounded-sm py-1.5 px-2 text-[10px] font-mono focus:outline-none focus:border-xmr-accent"
+                />
+                <button onClick={handleSweep} disabled={sweepBusy || !/^0x[0-9a-fA-F]{40}$/.test(sweepAddr)}
+                  className="px-3 py-1.5 border border-xmr-accent/50 text-xmr-accent rounded-sm text-[9px] font-black uppercase hover:bg-xmr-accent/10 disabled:opacity-30 disabled:cursor-not-allowed transition-all">
+                  {sweepBusy ? <Loader2 size={10} className="animate-spin" /> : 'Sweep'}
+                </button>
+                <button onClick={() => setShowSweep(false)} className="px-2 text-xmr-dim text-[9px] uppercase hover:text-current">Close</button>
+              </div>
+              {sweepError && <div className="text-[10px] text-xmr-error font-mono uppercase">{sweepError}</div>}
+            </div>
+          )}
+          {sweepResult && (
+            <div className="border border-xmr-green/30 bg-xmr-green/5 rounded-sm p-2 space-y-1">
+              <div className="text-[9px] text-xmr-green font-mono uppercase font-black">Leftovers swept</div>
+              <div className="text-[9px] font-mono text-xmr-dim break-all">TX: {sweepResult}</div>
+              <button onClick={() => { setSweepResult(null); setShowSweep(false); }}
+                className="text-[9px] text-xmr-dim uppercase hover:text-current">Done</button>
+            </div>
           )}
 
           <div className="text-[8px] text-xmr-dim/60 uppercase tracking-wider">

--- a/src/renderer/components/vigil/StrikeWalletPanel.tsx
+++ b/src/renderer/components/vigil/StrikeWalletPanel.tsx
@@ -36,6 +36,14 @@ export function StrikeWalletPanel({
   // Surface the backup prompt automatically right after key generation
   useEffect(() => { if (created) setShowExport(true); }, [created]);
 
+  // Auto-refresh balances while the panel is visible so incoming pre-funding
+  // shows up without manual refreshes
+  useEffect(() => {
+    if (!unlocked) return;
+    const interval = setInterval(() => { onRefresh().catch(() => { }); }, 30_000);
+    return () => clearInterval(interval);
+  }, [unlocked, onRefresh]);
+
   const handleUnlock = async () => {
     if (!password || busy) return;
     setBusy(true);
@@ -207,6 +215,10 @@ export function StrikeWalletPanel({
               <Eye size={10} /> Export / back up key
             </button>
           )}
+
+          <div className="text-[8px] text-xmr-dim/60 uppercase tracking-wider">
+            EVM RPC follows the app network mode — Tor-routed when Tor is enabled
+          </div>
         </div>
       )}
     </div>

--- a/src/renderer/components/vigil/VigilConfig.tsx
+++ b/src/renderer/components/vigil/VigilConfig.tsx
@@ -28,6 +28,9 @@ interface Props {
   setData: (data: any) => void;
   onArm: () => void;
   currentPrice: number;
+  /** External arming block (e.g. strike wallet not funded yet) */
+  armDisabled?: boolean;
+  armDisabledReason?: string;
 }
 
 // ─── Hold-to-Arm Button ───
@@ -122,7 +125,7 @@ function HoldToArmButton({
 
 // ─── Main Component ───
 
-export function VigilConfig({ mode, setMode, data, setData, onArm, currentPrice }: Props) {
+export function VigilConfig({ mode, setMode, data, setData, onArm, currentPrice, armDisabled, armDisabledReason }: Props) {
   const isSnipe = mode === 'SNIPE';
   const { currencies, loading: isCurrencyLoading } = useCurrencies();
   const [useStop, setUseStop] = useState(false);
@@ -512,7 +515,8 @@ export function VigilConfig({ mode, setMode, data, setData, onArm, currentPrice 
       {/* ─── Arm Button ─── */}
       <HoldToArmButton
         onComplete={onArm}
-        disabled={!data.triggerPrice || !data.amount || !data.inputCurrency || !data.outputCurrency || !isValid || !!amountError}
+        disabled={!data.triggerPrice || !data.amount || !data.inputCurrency || !data.outputCurrency || !isValid || !!amountError || armDisabled}
+        label={armDisabled && armDisabledReason ? armDisabledReason : 'INITIALIZE VIGIL'}
       />
     </div>
   );

--- a/src/renderer/components/vigil/VigilConfig.tsx
+++ b/src/renderer/components/vigil/VigilConfig.tsx
@@ -518,6 +518,11 @@ export function VigilConfig({ mode, setMode, data, setData, onArm, currentPrice,
         disabled={!data.triggerPrice || !data.amount || !data.inputCurrency || !data.outputCurrency || !isValid || !!amountError || armDisabled}
         label={armDisabled && armDisabledReason ? armDisabledReason : 'INITIALIZE VIGIL'}
       />
+      {!isSnipe && (
+        <p className="text-[9px] text-xmr-dim font-mono uppercase tracking-wider text-center">
+          While armed, the vault stays open behind the lock screen so this order can execute unattended. Abort the vigil to fully lock.
+        </p>
+      )}
     </div>
   );
 }

--- a/src/renderer/components/vigil/VigilDashboard.tsx
+++ b/src/renderer/components/vigil/VigilDashboard.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { useState, useEffect, useRef } from 'react';
 import { Radio, XCircle, Shield, ArrowDown, Copy, Check } from 'lucide-react';
+import { HeartbeatChart } from './HeartbeatChart';
 // Lightweight toast-like notification (avoids react-hot-toast dependency)
 const notify = (msg: string) => console.log(`[Vigil] ${msg}`);
 
@@ -21,6 +22,7 @@ interface Props {
   realPrice?: number | null;
   priceConnected?: boolean;
   externalLogs?: LogLine[];
+  priceHistory?: { time: number; value: number }[];
 }
 
 // ─── Main Component ───
@@ -33,6 +35,7 @@ export function VigilDashboard({
   realPrice,
   priceConnected = true,
   externalLogs = [],
+  priceHistory = [],
 }: Props) {
   const isTriggered = state === 'TRIGGERED' || state === 'EXECUTING';
   const displayPrice = realPrice ?? parseFloat(config.triggerPrice) ?? 0;
@@ -144,6 +147,18 @@ export function VigilDashboard({
           </div>
 
           {/* ─── Target Lines ─── */}
+          {/* Live heartbeat chart (built from the WS tick buffer) */}
+          <div className="mb-4">
+            <HeartbeatChart
+              triggerPrice={triggerVal}
+              stopPrice={hasStop ? parseFloat(config.stopPrice) : undefined}
+              mode={mode}
+              isTriggered={isTriggered}
+              realPrice={realPrice}
+              priceHistory={priceHistory}
+            />
+          </div>
+
           <div className="grid grid-cols-2 gap-4">
             {/* Main Target */}
             <div className="p-3 rounded-sm border border-xmr-green/20 bg-xmr-green/5 space-y-1">

--- a/src/renderer/components/vigil/VigilDashboard.tsx
+++ b/src/renderer/components/vigil/VigilDashboard.tsx
@@ -161,7 +161,7 @@ export function VigilDashboard({
           {/* ─── Target Lines ─── */}
           <div className="grid grid-cols-2 gap-4">
             {/* Main Target */}
-            <div className="p-3 rounded-sm border border-xmr-green/20 bg-xmr-green/5 space-y-1">
+            <div className="p-3 rounded-sm border border-xmr-green/20 bg-xmr-surface/70 backdrop-blur-sm space-y-1">
               <div className="text-[9px] text-xmr-dim font-mono uppercase tracking-widest flex items-center gap-1.5">
                 <div className="w-1.5 h-1.5 rounded-full bg-xmr-green" />
                 {mode === 'SNIPE' ? 'BUY DIP TARGET' : 'TAKE PROFIT TARGET'}
@@ -173,11 +173,8 @@ export function VigilDashboard({
             </div>
 
             {/* Stop / Strategy */}
-            <div className={`p-3 rounded-sm border space-y-1
-              ${hasStop
-                ? 'border-xmr-error/20 bg-xmr-error/5'
-                : 'border-xmr-border/20 bg-xmr-surface/30'
-              }
+            <div className={`p-3 rounded-sm border space-y-1 bg-xmr-surface/70 backdrop-blur-sm
+              ${hasStop ? 'border-xmr-error/20' : 'border-xmr-border/20'}
             `}>
               {hasStop ? (
                 <>

--- a/src/renderer/components/vigil/VigilDashboard.tsx
+++ b/src/renderer/components/vigil/VigilDashboard.tsx
@@ -101,6 +101,18 @@ export function VigilDashboard({
           <div className="absolute inset-0 bg-xmr-error/5 animate-pulse" />
         )}
 
+        {/* Live heartbeat chart as the card's background layer (web parity) */}
+        <div className="absolute inset-0 top-16 z-0">
+          <HeartbeatChart
+            triggerPrice={triggerVal}
+            stopPrice={hasStop ? parseFloat(config.stopPrice) : undefined}
+            mode={mode}
+            isTriggered={isTriggered}
+            realPrice={realPrice}
+            priceHistory={priceHistory}
+          />
+        </div>
+
         <div className="relative z-10">
           {/* Top bar */}
           <div className="flex justify-between items-start mb-6">
@@ -147,18 +159,6 @@ export function VigilDashboard({
           </div>
 
           {/* ─── Target Lines ─── */}
-          {/* Live heartbeat chart (built from the WS tick buffer) */}
-          <div className="mb-4">
-            <HeartbeatChart
-              triggerPrice={triggerVal}
-              stopPrice={hasStop ? parseFloat(config.stopPrice) : undefined}
-              mode={mode}
-              isTriggered={isTriggered}
-              realPrice={realPrice}
-              priceHistory={priceHistory}
-            />
-          </div>
-
           <div className="grid grid-cols-2 gap-4">
             {/* Main Target */}
             <div className="p-3 rounded-sm border border-xmr-green/20 bg-xmr-green/5 space-y-1">

--- a/src/renderer/components/vigil/VigilDashboard.tsx
+++ b/src/renderer/components/vigil/VigilDashboard.tsx
@@ -159,9 +159,9 @@ export function VigilDashboard({
           </div>
 
           {/* ─── Target Lines ─── */}
-          <div className="grid grid-cols-2 gap-4">
+          <div className="grid grid-cols-2 gap-4 mt-24">
             {/* Main Target */}
-            <div className="p-3 rounded-sm border border-xmr-green/20 bg-xmr-surface/70 backdrop-blur-sm space-y-1">
+            <div className="p-3 rounded-sm border border-xmr-green/20 bg-xmr-surface/35 backdrop-blur-[2px] space-y-1">
               <div className="text-[9px] text-xmr-dim font-mono uppercase tracking-widest flex items-center gap-1.5">
                 <div className="w-1.5 h-1.5 rounded-full bg-xmr-green" />
                 {mode === 'SNIPE' ? 'BUY DIP TARGET' : 'TAKE PROFIT TARGET'}
@@ -173,7 +173,7 @@ export function VigilDashboard({
             </div>
 
             {/* Stop / Strategy */}
-            <div className={`p-3 rounded-sm border space-y-1 bg-xmr-surface/70 backdrop-blur-sm
+            <div className={`p-3 rounded-sm border space-y-1 bg-xmr-surface/35 backdrop-blur-[2px]
               ${hasStop ? 'border-xmr-error/20' : 'border-xmr-border/20'}
             `}>
               {hasStop ? (

--- a/src/renderer/contexts/VaultContext.tsx
+++ b/src/renderer/contexts/VaultContext.tsx
@@ -1,4 +1,5 @@
 import React, { createContext, useContext, useState, useEffect, useCallback, useRef } from 'react';
+import { vigilKeepsWalletOpen } from '../utils/vigilHotWallet';
 import { WalletService, Transaction } from '../services/walletService';
 
 export interface Identity { id: string; name: string; created: number; }
@@ -478,7 +479,15 @@ export function VaultProvider({ children }: { children: React.ReactNode }) {
     setStatus('READY');
 
     // 3. ⏳ Signal Soft Lock to backend (keeps RPC alive but acknowledges lock)
-    window.api.walletAction('close', {}).catch(() => { });
+    // — unless an armed EJECT vigil needs the wallet hot to execute
+    // unattended. The UI still locks and renderer state is purged above;
+    // only the wallet-rpc close is skipped. The vigil engine closes the
+    // wallet itself when the order reaches a terminal state while locked.
+    if (vigilKeepsWalletOpen()) {
+      console.log('🔒 UI locked — vault stays hot for armed EJECT vigil.');
+    } else {
+      window.api.walletAction('close', {}).catch(() => { });
+    }
 
   }, [addLog]);
 

--- a/src/renderer/contexts/VigilContext.tsx
+++ b/src/renderer/contexts/VigilContext.tsx
@@ -1,0 +1,26 @@
+import { createContext, useContext, type ReactNode } from 'react';
+import { useVigilEngine } from '../hooks/useVigilEngine';
+
+/**
+ * Hosts the single vigil engine instance ABOVE the lock gate so an armed
+ * session survives lock/unlock cycles: the Kraken feed keeps ticking, SNIPE
+ * executes fully while locked (the strike key and destination need no open
+ * vault), and EJECT holds in PAUSED_LOCKED until unlock. The engine now
+ * unmounts only on app quit — the persisted-session/re-arm path still covers
+ * that. Exactly one armed session exists by construction (one provider).
+ */
+
+type VigilEngineApi = ReturnType<typeof useVigilEngine>;
+
+const VigilContext = createContext<VigilEngineApi | null>(null);
+
+export function VigilProvider({ children }: { children: ReactNode }) {
+  const engine = useVigilEngine();
+  return <VigilContext.Provider value={engine}>{children}</VigilContext.Provider>;
+}
+
+export function useVigil(): VigilEngineApi {
+  const ctx = useContext(VigilContext);
+  if (!ctx) throw new Error('useVigil must be used within VigilProvider');
+  return ctx;
+}

--- a/src/renderer/hooks/__tests__/vigilLogic.test.ts
+++ b/src/renderer/hooks/__tests__/vigilLogic.test.ts
@@ -115,3 +115,30 @@ describe('loadPersistedSession', () => {
     expect(loadPersistedSession({ ...valid, triggers: 'nope' }, 'vault_123')).toBeNull();
   });
 });
+
+import { pushTick, TICK_CAP, type TickPoint } from '../usePriceWatcher';
+
+describe('pushTick (heartbeat chart buffer)', () => {
+  it('collapses ticks in the same 2s window, latest wins', () => {
+    const buf: TickPoint[] = [];
+    pushTick(buf, 100, 10);
+    pushTick(buf, 101, 11); // same window (100-101)
+    expect(buf).toEqual([{ time: 100, value: 11 }]);
+    pushTick(buf, 102, 12); // next window
+    expect(buf).toEqual([{ time: 100, value: 11 }, { time: 102, value: 12 }]);
+  });
+
+  it('ignores out-of-order ticks', () => {
+    const buf: TickPoint[] = [{ time: 200, value: 5 }];
+    pushTick(buf, 150, 9);
+    expect(buf).toEqual([{ time: 200, value: 5 }]);
+  });
+
+  it('caps the buffer at TICK_CAP points, dropping the oldest', () => {
+    const buf: TickPoint[] = [];
+    for (let i = 0; i <= TICK_CAP; i++) pushTick(buf, i * 2, i);
+    expect(buf.length).toBe(TICK_CAP);
+    expect(buf[0].time).toBe(2); // oldest (0) shifted out
+    expect(buf[buf.length - 1].value).toBe(TICK_CAP);
+  });
+});

--- a/src/renderer/hooks/__tests__/vigilLogic.test.ts
+++ b/src/renderer/hooks/__tests__/vigilLogic.test.ts
@@ -1,6 +1,22 @@
 import { describe, it, expect } from 'vitest';
 import { evaluateTriggers, getKrakenMonitoringPair, type PriceTrigger } from '../usePriceWatcher';
 import { buildTriggers, loadPersistedSession, VIGIL_SESSION_VERSION, type PersistedVigilSession } from '../useVigilEngine';
+import { isNativeEVM, getTokenConfig } from '@kyc-rip/stealth-engines/chains';
+
+describe('chains registry (strike wallet dependencies)', () => {
+  it('classifies native coins the strike wallet relies on', () => {
+    expect(isNativeEVM('eth')).toBe(true);
+    expect(isNativeEVM('ETH')).toBe(true);
+    expect(isNativeEVM('bnb')).toBe(true);
+    expect(isNativeEVM('usdt')).toBe(false);
+    expect(isNativeEVM('usdc')).toBe(false);
+  });
+
+  it('resolves ERC-20 contracts for the default SNIPE tokens', () => {
+    expect(getTokenConfig('usdt', 'ERC20')?.address).toMatch(/^0x[0-9a-fA-F]{40}$/);
+    expect(getTokenConfig('usdc', 'ERC20')?.address).toMatch(/^0x[0-9a-fA-F]{40}$/);
+  });
+});
 
 describe('evaluateTriggers', () => {
   const triggers: PriceTrigger[] = [

--- a/src/renderer/hooks/__tests__/vigilLogic.test.ts
+++ b/src/renderer/hooks/__tests__/vigilLogic.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from 'vitest';
+import { evaluateTriggers, getKrakenMonitoringPair, type PriceTrigger } from '../usePriceWatcher';
+import { buildTriggers, loadPersistedSession, VIGIL_SESSION_VERSION, type PersistedVigilSession } from '../useVigilEngine';
+
+describe('evaluateTriggers', () => {
+  const triggers: PriceTrigger[] = [
+    { id: 'BUY_DIP', operator: '<=', price: 150 },
+    { id: 'BUY_BREAKOUT', operator: '>=', price: 200 },
+  ];
+
+  it('fires <= when price is at or below the threshold', () => {
+    expect(evaluateTriggers(triggers, 150)?.id).toBe('BUY_DIP');
+    expect(evaluateTriggers(triggers, 149.99)?.id).toBe('BUY_DIP');
+  });
+
+  it('fires >= when price is at or above the threshold', () => {
+    expect(evaluateTriggers(triggers, 200)?.id).toBe('BUY_BREAKOUT');
+    expect(evaluateTriggers(triggers, 250)?.id).toBe('BUY_BREAKOUT');
+  });
+
+  it('returns null between thresholds', () => {
+    expect(evaluateTriggers(triggers, 175)).toBeNull();
+  });
+
+  it('returns null with no triggers', () => {
+    expect(evaluateTriggers([], 175)).toBeNull();
+  });
+});
+
+describe('buildTriggers', () => {
+  it('SNIPE: main is buy-the-dip (<=), stop is breakout (>=)', () => {
+    expect(buildTriggers('SNIPE', '150', '200')).toEqual([
+      { id: 'BUY_DIP', operator: '<=', price: 150 },
+      { id: 'BUY_BREAKOUT', operator: '>=', price: 200 },
+    ]);
+  });
+
+  it('EJECT: main is take-profit (>=), stop is stop-loss (<=)', () => {
+    expect(buildTriggers('EJECT', '300', '120')).toEqual([
+      { id: 'TAKE_PROFIT', operator: '>=', price: 300 },
+      { id: 'STOP_LOSS', operator: '<=', price: 120 },
+    ]);
+  });
+
+  it('omits unset or non-positive prices', () => {
+    expect(buildTriggers('SNIPE', '150')).toHaveLength(1);
+    expect(buildTriggers('SNIPE', '0', '0')).toHaveLength(0);
+    expect(buildTriggers('EJECT', '', '')).toHaveLength(0);
+  });
+});
+
+describe('getKrakenMonitoringPair', () => {
+  it('maps stable->XMR snipes and XMR->stable ejects to XMR/USD', () => {
+    expect(getKrakenMonitoringPair('SNIPE', 'USDT', 'XMR')).toBe('XMR/USD');
+    expect(getKrakenMonitoringPair('SNIPE', 'USDC', 'XMR')).toBe('XMR/USD');
+    expect(getKrakenMonitoringPair('EJECT', 'XMR', 'USDT')).toBe('XMR/USD');
+    expect(getKrakenMonitoringPair('EJECT', 'XMR', 'DAI')).toBe('XMR/USD');
+  });
+
+  it('normalizes stagenet tickers', () => {
+    expect(getKrakenMonitoringPair('EJECT', 'SXMR', 'USDT')).toBe('XMR/USD');
+  });
+
+  it('falls back to the non-USD leg when the subject is a fiat proxy', () => {
+    expect(getKrakenMonitoringPair('SNIPE', 'ETH', 'USDT')).toBe('ETH/USD');
+  });
+});
+
+describe('loadPersistedSession', () => {
+  const valid: PersistedVigilSession = {
+    version: VIGIL_SESSION_VERSION,
+    identityId: 'vault_123',
+    mode: 'SNIPE',
+    phase: 'ARMED',
+    triggers: [{ id: 'BUY_DIP', operator: '<=', price: 150 }],
+    config: {
+      triggerPrice: '150', amount: '100', targetAddress: '4abc',
+      compliance: { kyc: 'ANY', log: 'ANY' } as never,
+    },
+    createdAt: 1,
+  };
+
+  it('accepts a valid v1 session for the matching identity', () => {
+    expect(loadPersistedSession(valid, 'vault_123')).toEqual(valid);
+  });
+
+  it('rejects sessions from a different identity', () => {
+    expect(loadPersistedSession(valid, 'vault_other')).toBeNull();
+  });
+
+  it('rejects newer schema versions instead of corrupting', () => {
+    expect(loadPersistedSession({ ...valid, version: 2 }, 'vault_123')).toBeNull();
+  });
+
+  it('rejects malformed blobs', () => {
+    expect(loadPersistedSession(null, 'vault_123')).toBeNull();
+    expect(loadPersistedSession({ ...valid, mode: 'YOLO' }, 'vault_123')).toBeNull();
+    expect(loadPersistedSession({ ...valid, phase: 'DONE' }, 'vault_123')).toBeNull();
+    expect(loadPersistedSession({ ...valid, triggers: 'nope' }, 'vault_123')).toBeNull();
+  });
+});

--- a/src/renderer/hooks/useFiatValue.ts
+++ b/src/renderer/hooks/useFiatValue.ts
@@ -1,5 +1,6 @@
 // ui/src/hooks/useFiatValue.ts
 import { useState, useEffect } from 'react';
+import { getApiBase } from '../services/client';
 
 // struct: { "BTC": { price: 98000, timestamp: 1712345678900 } }
 const priceCache: Record<string, { price: number; timestamp: number }> = {};
@@ -70,17 +71,16 @@ export function useFiatValue(ticker?: string, amount?: string | number, withPref
       return;
     }
 
-    // CryptoCompare's free min-api now requires an API key (401), so we
-    // chain keyless public sources: Kraken first (lists XMR; Binance
-    // delisted it and serves frozen prices), then CoinGecko.
-    const fetchKraken = async (): Promise<number | null> => {
-      const pair = `${sym === 'BTC' ? 'XBT' : sym}USD`;
-      const res = await fetch(`https://api.kraken.com/0/public/Ticker?pair=${pair}`);
+    // Primary: our own API (CORS-enabled, multi-source server-side chain,
+    // KV-cached ~5min, reachable over Tor like all api.kyc.rip traffic).
+    // Kraken/Binance REST block browser CORS, so they are useless from the
+    // renderer; CoinGecko allows CORS and serves as the only direct fallback.
+    const fetchKycRip = async (): Promise<number | null> => {
+      const base = getApiBase().replace(/\/$/, '');
+      const res = await fetch(`${base}/v1/price/${sym}`);
+      if (!res.ok) return null;
       const data = await res.json();
-      if (data.error?.length || !data.result) return null;
-      const first = Object.values(data.result)[0] as { c?: string[] };
-      const price = parseFloat(first?.c?.[0] || '');
-      return price > 0 ? price : null;
+      return data?.usd > 0 ? data.usd : null;
     };
 
     const COINGECKO_IDS: Record<string, string> = {
@@ -100,7 +100,7 @@ export function useFiatValue(ticker?: string, amount?: string | number, withPref
     };
 
     const fetchValue = async () => {
-      for (const source of [fetchKraken, fetchCoinGecko]) {
+      for (const source of [fetchKycRip, fetchCoinGecko]) {
         try {
           const price = await source();
           if (price) {

--- a/src/renderer/hooks/useFiatValue.ts
+++ b/src/renderer/hooks/useFiatValue.ts
@@ -70,17 +70,47 @@ export function useFiatValue(ticker?: string, amount?: string | number, withPref
       return;
     }
 
+    // CryptoCompare's free min-api now requires an API key (401), so we
+    // chain keyless public sources: Kraken first (lists XMR; Binance
+    // delisted it and serves frozen prices), then CoinGecko.
+    const fetchKraken = async (): Promise<number | null> => {
+      const pair = `${sym === 'BTC' ? 'XBT' : sym}USD`;
+      const res = await fetch(`https://api.kraken.com/0/public/Ticker?pair=${pair}`);
+      const data = await res.json();
+      if (data.error?.length || !data.result) return null;
+      const first = Object.values(data.result)[0] as { c?: string[] };
+      const price = parseFloat(first?.c?.[0] || '');
+      return price > 0 ? price : null;
+    };
+
+    const COINGECKO_IDS: Record<string, string> = {
+      BTC: 'bitcoin', ETH: 'ethereum', XMR: 'monero', SOL: 'solana',
+      LTC: 'litecoin', BCH: 'bitcoin-cash', DOGE: 'dogecoin', BNB: 'binancecoin',
+      TRX: 'tron', XRP: 'ripple', AVAX: 'avalanche-2', POL: 'matic-network',
+      MATIC: 'matic-network', ZEC: 'zcash',
+    };
+
+    const fetchCoinGecko = async (): Promise<number | null> => {
+      const id = COINGECKO_IDS[sym];
+      if (!id) return null;
+      const res = await fetch(`https://api.coingecko.com/api/v3/simple/price?ids=${id}&vs_currencies=usd`);
+      const data = await res.json();
+      const price = data?.[id]?.usd;
+      return price > 0 ? price : null;
+    };
+
     const fetchValue = async () => {
-      try {
-        const res = await fetch(`https://min-api.cryptocompare.com/data/price?fsym=${sym}&tsyms=USD`);
-        const data = await res.json();
-        
-        if (data.USD) {
-          priceCache[sym] = { price: data.USD, timestamp: Date.now() };
-          updateUI(data.USD);
+      for (const source of [fetchKraken, fetchCoinGecko]) {
+        try {
+          const price = await source();
+          if (price) {
+            priceCache[sym] = { price, timestamp: Date.now() };
+            updateUI(price);
+            return;
+          }
+        } catch (e) {
+          console.warn('Fiat fetch error:', e);
         }
-      } catch (e) {
-        console.warn('Fiat fetch error:', e);
       }
     };
 

--- a/src/renderer/hooks/usePriceWatcher.ts
+++ b/src/renderer/hooks/usePriceWatcher.ts
@@ -69,7 +69,20 @@ export function usePriceWatcher(onTrigger: (price: number, trigger: PriceTrigger
     try {
       const ws = new WebSocket(KRAKEN_WS);
 
+      // Proxies that blackhole the connection (no RST) leave the socket in
+      // CONNECTING until the OS TCP timeout (~75s), which delays the whole
+      // backoff->degraded escalation by minutes. Force-close stuck handshakes
+      // so onclose fires and the normal retry path takes over quickly.
+      const connectTimeout = setTimeout(() => {
+        if (ws.readyState === WebSocket.CONNECTING) {
+          console.warn('[PriceWatcher] WS handshake timed out after 15s (proxy blackhole?). Forcing retry.');
+          connectingRef.current = false;
+          try { ws.close(); } catch { /* noop */ }
+        }
+      }, 15_000);
+
       ws.onopen = () => {
+        clearTimeout(connectTimeout);
         connectingRef.current = false;
         failuresRef.current = 0;
         setConnected(true);
@@ -114,6 +127,7 @@ export function usePriceWatcher(onTrigger: (price: number, trigger: PriceTrigger
       };
 
       ws.onclose = (event) => {
+        clearTimeout(connectTimeout);
         connectingRef.current = false;
         setConnected(false);
 

--- a/src/renderer/hooks/usePriceWatcher.ts
+++ b/src/renderer/hooks/usePriceWatcher.ts
@@ -213,6 +213,28 @@ export function usePriceWatcher(onTrigger: (price: number, trigger: PriceTrigger
     failuresRef.current = 0;
     setDegraded(false);
     connect(krakenPair);
+
+    // Seed the chart with 1-min OHLC closes (fetched in the main process —
+    // Kraken REST blocks renderer CORS) so the chart is complete instantly
+    // instead of accumulating from zero. Live ticks append after the last
+    // candle; older candles are merged in front of anything already buffered.
+    window.api.fetchPriceHistory(krakenPair).then((res) => {
+      if (!res.success || !res.points?.length) {
+        if (res.error) console.warn('[PriceWatcher] History seed unavailable:', res.error);
+        return;
+      }
+      const existing = historyRef.current;
+      const cutoff = existing.length > 0 ? existing[0].time : Infinity;
+      const older = res.points.filter(p => p.time < cutoff).sort((a, b) => a.time - b.time);
+      if (older.length === 0) return;
+      historyRef.current = [...older, ...existing].slice(-TICK_CAP);
+      setPriceHistory([...historyRef.current]);
+      if (!priceRef.current) {
+        const latest = historyRef.current[historyRef.current.length - 1];
+        priceRef.current = latest.value;
+        setPrice(latest.value);
+      }
+    }).catch((e) => console.warn('[PriceWatcher] History seed failed:', e));
   }, [connect]);
 
   /** Manual reconnect from the degraded-state banner. */

--- a/src/renderer/hooks/usePriceWatcher.ts
+++ b/src/renderer/hooks/usePriceWatcher.ts
@@ -113,10 +113,18 @@ export function usePriceWatcher(onTrigger: (price: number, trigger: PriceTrigger
         failuresRef.current = 0;
         setConnected(true);
         setDegraded(false);
+        // Trade channel fires only on executed trades — on a thin pair that
+        // can be minutes apart. Ticker fires on every book update, keeping
+        // the price and the chart buffer lively; both carry the last price.
         ws.send(JSON.stringify({
           event: 'subscribe',
           pair: [krakenPair],
           subscription: { name: 'trade' },
+        }));
+        ws.send(JSON.stringify({
+          event: 'subscribe',
+          pair: [krakenPair],
+          subscription: { name: 'ticker' },
         }));
       };
 
@@ -139,10 +147,16 @@ export function usePriceWatcher(onTrigger: (price: number, trigger: PriceTrigger
           }
 
           // Trade data: [channelId, [[price, vol, time, side]], "trade", pair]
-          if (Array.isArray(data) && data[2] === 'trade') {
-            const trades = data[1];
-            const latest = trades[trades.length - 1];
-            const currentPrice = parseFloat(latest[0]);
+          // Ticker data: [channelId, {c: [lastPrice, lastVol], ...}, "ticker", pair]
+          if (Array.isArray(data) && (data[2] === 'trade' || data[2] === 'ticker')) {
+            let currentPrice = NaN;
+            if (data[2] === 'trade') {
+              const trades = data[1];
+              currentPrice = parseFloat(trades[trades.length - 1][0]);
+            } else {
+              currentPrice = parseFloat(data[1]?.c?.[0]);
+            }
+            if (!(currentPrice > 0)) return;
             setPrice(currentPrice);
             setLastTickAt(Date.now());
 

--- a/src/renderer/hooks/usePriceWatcher.ts
+++ b/src/renderer/hooks/usePriceWatcher.ts
@@ -1,0 +1,193 @@
+import { useState, useRef, useCallback, useEffect } from 'react';
+
+/**
+ * Kraken trade-feed price watcher with trigger evaluation.
+ *
+ * Owns the WebSocket lifecycle: reconnects with exponential backoff
+ * (5s -> 60s); after MAX_CONSECUTIVE_FAILURES it stops retrying and surfaces
+ * `degraded: true` so the UI can show a stale-feed banner with a manual
+ * reconnect — armed triggers are kept, never silently dropped.
+ *
+ * The WS rides the app-wide session proxy (Tor when enabled), like all
+ * renderer network traffic.
+ */
+
+export interface PriceTrigger {
+  id: string;
+  operator: '>=' | '<=';
+  price: number;
+}
+
+export function evaluateTriggers(triggers: PriceTrigger[], price: number): PriceTrigger | null {
+  for (const trigger of triggers) {
+    if (trigger.operator === '>=' && price >= trigger.price) return trigger;
+    if (trigger.operator === '<=' && price <= trigger.price) return trigger;
+  }
+  return null;
+}
+
+const KRAKEN_WS = 'wss://ws.kraken.com';
+const BACKOFF_BASE_MS = 5_000;
+const BACKOFF_MAX_MS = 60_000;
+const MAX_CONSECUTIVE_FAILURES = 5;
+
+export function usePriceWatcher(onTrigger: (price: number, trigger: PriceTrigger) => void) {
+  const [price, setPrice] = useState<number | null>(null);
+  const [connected, setConnected] = useState(false);
+  const [degraded, setDegraded] = useState(false);
+  const [lastTickAt, setLastTickAt] = useState<number | null>(null);
+
+  const wsRef = useRef<WebSocket | null>(null);
+  const retryTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const triggersRef = useRef<PriceTrigger[]>([]);
+  const pairRef = useRef<string>('');
+  const failuresRef = useRef(0);
+  const connectingRef = useRef(false);
+  const onTriggerRef = useRef(onTrigger);
+  useEffect(() => { onTriggerRef.current = onTrigger; }, [onTrigger]);
+
+  const closeSocket = useCallback(() => {
+    if (wsRef.current) {
+      wsRef.current.onclose = null;
+      wsRef.current.onerror = null;
+      wsRef.current.onmessage = null;
+      try { wsRef.current.close(); } catch { /* noop */ }
+      wsRef.current = null;
+    }
+    if (retryTimeoutRef.current) {
+      clearTimeout(retryTimeoutRef.current);
+      retryTimeoutRef.current = null;
+    }
+  }, []);
+
+  const connect = useCallback((krakenPair: string) => {
+    if (connectingRef.current) return;
+    closeSocket();
+    connectingRef.current = true;
+    pairRef.current = krakenPair;
+
+    try {
+      const ws = new WebSocket(KRAKEN_WS);
+
+      ws.onopen = () => {
+        connectingRef.current = false;
+        failuresRef.current = 0;
+        setConnected(true);
+        setDegraded(false);
+        ws.send(JSON.stringify({
+          event: 'subscribe',
+          pair: [krakenPair],
+          subscription: { name: 'trade' },
+        }));
+      };
+
+      ws.onmessage = (event) => {
+        try {
+          const data = JSON.parse(event.data);
+          if (data.event === 'heartbeat' || data.event === 'systemStatus') return;
+
+          if (data.event === 'subscriptionStatus') {
+            if (data.status === 'error') {
+              console.error(`[PriceWatcher] Kraken subscription error: ${data.errorMessage}`);
+              // Unknown pair: retrying won't help, stop and surface degraded
+              if (data.errorMessage?.includes('pair') || data.errorMessage?.includes('Currency')) {
+                closeSocket();
+                setConnected(false);
+                setDegraded(true);
+              }
+            }
+            return;
+          }
+
+          // Trade data: [channelId, [[price, vol, time, side]], "trade", pair]
+          if (Array.isArray(data) && data[2] === 'trade') {
+            const trades = data[1];
+            const latest = trades[trades.length - 1];
+            const currentPrice = parseFloat(latest[0]);
+            setPrice(currentPrice);
+            setLastTickAt(Date.now());
+
+            const hit = evaluateTriggers(triggersRef.current, currentPrice);
+            if (hit) onTriggerRef.current(currentPrice, hit);
+          }
+        } catch { /* ignore malformed packets */ }
+      };
+
+      ws.onclose = (event) => {
+        connectingRef.current = false;
+        setConnected(false);
+
+        if (triggersRef.current.length === 0) return; // nothing armed, stay quiet
+
+        failuresRef.current += 1;
+        if (failuresRef.current >= MAX_CONSECUTIVE_FAILURES) {
+          console.warn(`[PriceWatcher] WS failed ${failuresRef.current}x — entering degraded mode (manual reconnect required).`);
+          setDegraded(true);
+          return;
+        }
+
+        const delay = Math.min(BACKOFF_BASE_MS * 2 ** (failuresRef.current - 1), BACKOFF_MAX_MS);
+        console.warn(`[PriceWatcher] WS closed (code ${event.code}). Reconnecting in ${delay / 1000}s...`);
+        retryTimeoutRef.current = setTimeout(() => {
+          if (triggersRef.current.length > 0) connect(krakenPair);
+        }, delay);
+      };
+
+      ws.onerror = () => { /* onclose fires next and handles retry */ };
+
+      wsRef.current = ws;
+    } catch (e) {
+      connectingRef.current = false;
+      console.error('[PriceWatcher] WS init failed:', e);
+    }
+  }, [closeSocket]);
+
+  /** Arm triggers and start (or retarget) the feed. */
+  const watch = useCallback((krakenPair: string, triggers: PriceTrigger[]) => {
+    triggersRef.current = triggers;
+    failuresRef.current = 0;
+    setDegraded(false);
+    connect(krakenPair);
+  }, [connect]);
+
+  /** Manual reconnect from the degraded-state banner. */
+  const reconnect = useCallback(() => {
+    failuresRef.current = 0;
+    setDegraded(false);
+    if (pairRef.current) connect(pairRef.current);
+  }, [connect]);
+
+  /** Disarm and close the feed. */
+  const stop = useCallback(() => {
+    triggersRef.current = [];
+    closeSocket();
+    setConnected(false);
+    setDegraded(false);
+  }, [closeSocket]);
+
+  useEffect(() => () => { triggersRef.current = []; closeSocket(); }, [closeSocket]);
+
+  return { price, connected, degraded, lastTickAt, watch, reconnect, stop, hasTriggers: () => triggersRef.current.length > 0, clearTriggers: () => { triggersRef.current = []; } };
+}
+
+/**
+ * Derives the Kraken monitoring pair from swap currencies.
+ * e.g. SNIPE USDT->XMR => "XMR/USD", EJECT XMR->USDT => "XMR/USD"
+ */
+export function getKrakenMonitoringPair(mode: 'SNIPE' | 'EJECT', from: string, to: string): string {
+  const clean = (t: string) =>
+    t.toUpperCase()
+      .replace(/S(XMR|ETH)/i, '$1')
+      .replace('USDT', 'USD')
+      .replace('USDC', 'USD')
+      .replace('DAI', 'USD');
+
+  const cFrom = clean(from);
+  const cTo = clean(to);
+
+  let subject = mode === 'SNIPE' ? cTo : cFrom;
+  if (['USD', 'EUR'].includes(subject)) {
+    subject = mode === 'SNIPE' ? cFrom : cTo;
+  }
+  return `${subject}/USD`;
+}

--- a/src/renderer/hooks/usePriceWatcher.ts
+++ b/src/renderer/hooks/usePriceWatcher.ts
@@ -64,6 +64,8 @@ export function usePriceWatcher(onTrigger: (price: number, trigger: PriceTrigger
   const historyRef = useRef<TickPoint[]>([]);
 
   const wsRef = useRef<WebSocket | null>(null);
+  const priceRef = useRef<number | null>(null);
+  const connectedRef = useRef(false);
   const retryTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const triggersRef = useRef<PriceTrigger[]>([]);
   const pairRef = useRef<string>('');
@@ -111,6 +113,7 @@ export function usePriceWatcher(onTrigger: (price: number, trigger: PriceTrigger
         clearTimeout(connectTimeout);
         connectingRef.current = false;
         failuresRef.current = 0;
+        connectedRef.current = true;
         setConnected(true);
         setDegraded(false);
         // Trade channel fires only on executed trades — on a thin pair that
@@ -157,6 +160,7 @@ export function usePriceWatcher(onTrigger: (price: number, trigger: PriceTrigger
               currentPrice = parseFloat(data[1]?.c?.[0]);
             }
             if (!(currentPrice > 0)) return;
+            priceRef.current = currentPrice;
             setPrice(currentPrice);
             setLastTickAt(Date.now());
 
@@ -175,6 +179,7 @@ export function usePriceWatcher(onTrigger: (price: number, trigger: PriceTrigger
       ws.onclose = (event) => {
         clearTimeout(connectTimeout);
         connectingRef.current = false;
+        connectedRef.current = false;
         setConnected(false);
 
         if (triggersRef.current.length === 0) return; // nothing armed, stay quiet
@@ -224,6 +229,22 @@ export function usePriceWatcher(onTrigger: (price: number, trigger: PriceTrigger
     setConnected(false);
     setDegraded(false);
   }, [closeSocket]);
+
+  // Quiet markets starve the buffer, making the chart jump between scales
+  // whenever a lone tick finally lands. While the feed is up, repeat the
+  // last known price into each empty 2s window — the line stays continuous
+  // and the scale stays put even with no incoming trades.
+  useEffect(() => {
+    const heartbeat = setInterval(() => {
+      if (!connectedRef.current || !priceRef.current) return;
+      const before = historyRef.current.length;
+      pushTick(historyRef.current, Math.floor(Date.now() / 1000), priceRef.current);
+      if (historyRef.current.length !== before) {
+        setPriceHistory([...historyRef.current]);
+      }
+    }, TICK_WINDOW_S * 1000);
+    return () => clearInterval(heartbeat);
+  }, []);
 
   useEffect(() => () => { triggersRef.current = []; closeSocket(); }, [closeSocket]);
 

--- a/src/renderer/hooks/usePriceWatcher.ts
+++ b/src/renderer/hooks/usePriceWatcher.ts
@@ -26,6 +26,30 @@ export function evaluateTriggers(triggers: PriceTrigger[], price: number): Price
   return null;
 }
 
+export interface TickPoint { time: number; value: number }
+
+/**
+ * Rolling tick buffer for the heartbeat chart: keeps the LATEST tick per
+ * 2-second window (latest-wins preserves the trigger-relevant extreme at
+ * window close; no averaging), capped at 1800 points (~1 hour).
+ * Pure so it can be unit-tested; mutates and returns the same array unless
+ * the cap forces a shift.
+ */
+export const TICK_WINDOW_S = 2;
+export const TICK_CAP = 1800;
+export function pushTick(buffer: TickPoint[], time: number, value: number): TickPoint[] {
+  const windowTime = Math.floor(time / TICK_WINDOW_S) * TICK_WINDOW_S;
+  const last = buffer[buffer.length - 1];
+  if (last && last.time === windowTime) {
+    last.value = value; // same window: latest wins
+    return buffer;
+  }
+  if (last && windowTime < last.time) return buffer; // ignore out-of-order
+  buffer.push({ time: windowTime, value });
+  if (buffer.length > TICK_CAP) buffer.shift();
+  return buffer;
+}
+
 const KRAKEN_WS = 'wss://ws.kraken.com';
 const BACKOFF_BASE_MS = 5_000;
 const BACKOFF_MAX_MS = 60_000;
@@ -36,6 +60,8 @@ export function usePriceWatcher(onTrigger: (price: number, trigger: PriceTrigger
   const [connected, setConnected] = useState(false);
   const [degraded, setDegraded] = useState(false);
   const [lastTickAt, setLastTickAt] = useState<number | null>(null);
+  const [priceHistory, setPriceHistory] = useState<TickPoint[]>([]);
+  const historyRef = useRef<TickPoint[]>([]);
 
   const wsRef = useRef<WebSocket | null>(null);
   const retryTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -120,6 +146,12 @@ export function usePriceWatcher(onTrigger: (price: number, trigger: PriceTrigger
             setPrice(currentPrice);
             setLastTickAt(Date.now());
 
+            const before = historyRef.current.length;
+            pushTick(historyRef.current, Math.floor(Date.now() / 1000), currentPrice);
+            if (historyRef.current.length !== before) {
+              setPriceHistory([...historyRef.current]); // new window committed
+            }
+
             const hit = evaluateTriggers(triggersRef.current, currentPrice);
             if (hit) onTriggerRef.current(currentPrice, hit);
           }
@@ -181,7 +213,7 @@ export function usePriceWatcher(onTrigger: (price: number, trigger: PriceTrigger
 
   useEffect(() => () => { triggersRef.current = []; closeSocket(); }, [closeSocket]);
 
-  return { price, connected, degraded, lastTickAt, watch, reconnect, stop, hasTriggers: () => triggersRef.current.length > 0, clearTriggers: () => { triggersRef.current = []; } };
+  return { price, connected, degraded, lastTickAt, priceHistory, watch, reconnect, stop, hasTriggers: () => triggersRef.current.length > 0, clearTriggers: () => { triggersRef.current = []; } };
 }
 
 /**

--- a/src/renderer/hooks/useVigilEngine.ts
+++ b/src/renderer/hooks/useVigilEngine.ts
@@ -214,6 +214,16 @@ export function useVigilEngine() {
       console.warn('[Vigil] Failed to clear persisted session:', e));
   }, [identityId]);
 
+  // Identity switch invalidates the in-memory strike wallet — the new
+  // identity has its own key (and its own vault password).
+  useEffect(() => {
+    strikeRef.current = null;
+    setStrikeAddress('');
+    setStrikeBalances(null);
+    setStrikeGas(null);
+    setStrikeCreated(false);
+  }, [identityId]);
+
   // Load any persisted session for this identity on mount / identity switch
   useEffect(() => {
     let cancelled = false;
@@ -473,7 +483,9 @@ export function useVigilEngine() {
    * wallet. Must be called before arming a SNIPE.
    */
   const unlockStrike = useCallback(async (vaultPassword: string, network: string) => {
-    if (!identityId || identityId === 'primary') throw new Error('No active identity');
+    if (!identityId || identityId === 'primary') {
+      throw new Error('Vigil needs a named identity — create one in Settings before using the strike wallet');
+    }
 
     // Verify the password against the real vault before trusting it for
     // key encryption (same pattern as the dispatch password gate).
@@ -602,7 +614,9 @@ export function useVigilEngine() {
     const session = sessionRef.current;
     if (!payload || !session) return;
     logger('Retrying execution...', 'process');
-    setState('WATCHING'); // allow executeStrike's reentrancy guard to pass
+    // executeStrike refuses to run while state is TRIGGERED/EXECUTING (its
+    // reentrancy guard); stepping back to WATCHING is what re-opens the gate.
+    setState('WATCHING');
     await executeStrikeRef.current(payload);
   }, [logger]);
 

--- a/src/renderer/hooks/useVigilEngine.ts
+++ b/src/renderer/hooks/useVigilEngine.ts
@@ -417,7 +417,8 @@ export function useVigilEngine() {
         destinationAddress,
         provider: payload.provider,
         engine: payload.engine,
-        source: session.mode === 'SNIPE' ? 'ghost vigil' : 'ghost vigil sweep',
+        // Plain swaps, not ghost-bridge legs — name them for what they are
+        source: session.mode === 'SNIPE' ? 'vigil-snipe' : 'vigil-eject',
         fixed: false,
       });
 

--- a/src/renderer/hooks/useVigilEngine.ts
+++ b/src/renderer/hooks/useVigilEngine.ts
@@ -657,7 +657,7 @@ export function useVigilEngine() {
    * Refused while a vigil is active or while the burner still holds funds —
    * 'Sweep leftovers' first. The fresh key re-triggers the backup prompt.
    */
-  const regenerateStrike = useCallback(async (vaultPassword: string, network: string) => {
+  const regenerateStrike = useCallback(async (vaultPassword: string, network: string, selectedTicker?: string) => {
     if (!identityId || identityId === 'primary') throw new Error('No active identity');
     if (stateRef.current !== 'IDLE' && stateRef.current !== 'COMPLETED' && stateRef.current !== 'ERROR') {
       throw new Error('Disarm the vigil before rotating the burner');
@@ -665,10 +665,15 @@ export function useVigilEngine() {
     const strike = strikeRef.current;
     if (!strike) throw new Error('Unlock the strike wallet first');
 
-    // Zero-balance gate: no confirm dialog protects funds like refusing does
-    const tickers = ['USDT', 'USDC'];
+    // Zero-balance gate: no confirm dialog protects funds like refusing does.
+    // Checks the common SNIPE stables PLUS whatever ticker is currently
+    // selected in the config — a burner funded with e.g. DAI must not pass
+    // unseen. Tokens outside this set can't be detected (registry lookup is
+    // per-ticker); the sweep UI handles arbitrary tickers, so sweep first.
+    // Any token balance at all blocks; ETH allows true dust below sweepable.
+    const tickers = [...new Set(['USDT', 'USDC', selectedTicker?.toUpperCase()].filter(Boolean))] as string[];
     const balances = await strike.getBalances(tickers);
-    const hasToken = Object.values(balances.tokens).some(b => parseFloat(b || '0') > 0.01);
+    const hasToken = Object.values(balances.tokens).some(b => parseFloat(b || '0') > 0);
     if (hasToken || parseFloat(balances.eth || '0') > 0.0005) {
       throw new Error('Burner still holds funds — sweep leftovers before rotating');
     }

--- a/src/renderer/hooks/useVigilEngine.ts
+++ b/src/renderer/hooks/useVigilEngine.ts
@@ -1,15 +1,17 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { useState, useEffect, useRef, useCallback } from 'react';
-import { createTrade, type ComplianceState, type ComplianceLevel, type ExchangeRoute } from '../services/swap';
+import { createTrade, getTradeStatus, type ComplianceState, type ExchangeRoute } from '../services/swap';
 import { getApiBase } from '../services/client';
 import { useFiatValue } from './useFiatValue';
 import { useVault } from './useVault';
+import { usePriceWatcher, getKrakenMonitoringPair, type PriceTrigger } from './usePriceWatcher';
+import { StrikeWallet, type StrikeBalances, type GasCheck } from '../services/strikeWallet';
 
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
 
-export type EngineState = 'IDLE' | 'WATCHING' | 'TRIGGERED' | 'EXECUTING' | 'COMPLETED' | 'ERROR';
+export type EngineState = 'IDLE' | 'WATCHING' | 'TRIGGERED' | 'EXECUTING' | 'POLLING' | 'COMPLETED' | 'ERROR';
 
 export interface VigilSession {
   mode: 'SNIPE' | 'EJECT';
@@ -26,20 +28,27 @@ export interface VigilSession {
   state: EngineState;
 }
 
-interface VigilTrigger {
-  id: string;
-  operator: '>=' | '<=';
-  price: number;
+/** Persisted snapshot (schema v1). Never contains key material. */
+export interface PersistedVigilSession {
+  version: 1;
+  identityId: string;
+  mode: 'SNIPE' | 'EJECT';
+  phase: 'ARMED' | 'EXECUTING' | 'POLLING';
+  triggers: PriceTrigger[];
+  config: VigilSession['config'];
+  tradeId?: string;
+  txHash?: string;
+  createdAt: number;
 }
+
+export const VIGIL_SESSION_VERSION = 1;
 
 interface TriggerPayload {
   provider: string;
   engine: string;
-  eta: number;
   amount_to: number;
   krakenPrice: number;
   triggerId: string;
-  quote: ExchangeRoute;
 }
 
 interface LogEntry {
@@ -52,13 +61,6 @@ interface LogEntry {
 interface EstimateResponse {
   amount_to: number;
   routes: ExchangeRoute[];
-}
-
-interface DepositInfo {
-  address: string;
-  amount: number;
-  ticker: string;
-  memo?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -74,32 +76,52 @@ const getPrivacyParams = (c: ComplianceState) => ({
 });
 
 // ---------------------------------------------------------------------------
-// Kraken WebSocket Helpers
+// Helpers
 // ---------------------------------------------------------------------------
 
-const KRAKEN_WS = 'wss://ws.kraken.com';
+const currencyDefaults = (session: VigilSession) => ({
+  fromTicker: session.config.inputCurrency?.ticker || (session.mode === 'SNIPE' ? 'USDT' : 'XMR'),
+  fromNetwork: session.config.inputCurrency?.network || (session.mode === 'SNIPE' ? 'ERC20' : 'Mainnet'),
+  toTicker: session.config.outputCurrency?.ticker || (session.mode === 'SNIPE' ? 'XMR' : 'USDT'),
+  toNetwork: session.config.outputCurrency?.network || (session.mode === 'SNIPE' ? 'Mainnet' : 'ERC20'),
+});
 
-/**
- * Derives the Kraken monitoring pair from swap currencies.
- * e.g. SNIPE USDT->XMR  => "XMR/USD"
- *      EJECT XMR->USDT   => "XMR/USD"
- */
-const getKrakenMonitoringPair = (mode: 'SNIPE' | 'EJECT', from: string, to: string): string => {
-  const clean = (t: string) =>
-    t.toUpperCase()
-      .replace(/S(XMR|ETH)/i, '$1')
-      .replace('USDT', 'USD')
-      .replace('USDC', 'USD')
-      .replace('DAI', 'USD');
+export function buildTriggers(mode: 'SNIPE' | 'EJECT', triggerPrice: string, stopPrice?: string): PriceTrigger[] {
+  const triggers: PriceTrigger[] = [];
+  const pMain = parseFloat(triggerPrice || '0');
+  const pStop = parseFloat(stopPrice || '0');
 
-  const cFrom = clean(from);
-  const cTo = clean(to);
-
-  let subject = mode === 'SNIPE' ? cTo : cFrom;
-  if (['USD', 'EUR'].includes(subject)) {
-    subject = mode === 'SNIPE' ? cFrom : cTo;
+  if (mode === 'SNIPE') {
+    if (pMain > 0) triggers.push({ id: 'BUY_DIP', operator: '<=', price: pMain });
+    if (pStop > 0) triggers.push({ id: 'BUY_BREAKOUT', operator: '>=', price: pStop });
+  } else {
+    if (pMain > 0) triggers.push({ id: 'TAKE_PROFIT', operator: '>=', price: pMain });
+    if (pStop > 0) triggers.push({ id: 'STOP_LOSS', operator: '<=', price: pStop });
   }
-  return `${subject}/USD`;
+  return triggers;
+}
+
+/** Validates a persisted session blob; returns null for anything unusable. */
+export function loadPersistedSession(raw: any, identityId: string): PersistedVigilSession | null {
+  if (!raw || typeof raw !== 'object') return null;
+  if (raw.version !== VIGIL_SESSION_VERSION) {
+    console.warn(`[Vigil] Ignoring session with unsupported version ${raw.version} (created by a newer app?)`);
+    return null;
+  }
+  if (raw.identityId !== identityId) return null;
+  if (!['SNIPE', 'EJECT'].includes(raw.mode)) return null;
+  if (!['ARMED', 'EXECUTING', 'POLLING'].includes(raw.phase)) return null;
+  if (!Array.isArray(raw.triggers)) return null;
+  return raw as PersistedVigilSession;
+}
+
+// Status polling cadence
+const POLL_BASE_MS = 10_000;
+const POLL_MAX_MS = 60_000;
+const POLL_DEADLINE_MS = 24 * 60 * 60 * 1000;
+
+const STATUS_PROGRESS: Record<string, number> = {
+  WAITING: 20, CONFIRMING: 35, EXCHANGING: 60, SENDING: 85, FINISHED: 100,
 };
 
 // ---------------------------------------------------------------------------
@@ -113,7 +135,6 @@ export function useVigilEngine() {
   const [executionStatus, setExecutionStatus] = useState<string>('');
   const [progress, setProgress] = useState<number>(0);
   const [activeSession, setActiveSession] = useState<VigilSession | null>(null);
-  const [wsConnected, setWsConnected] = useState(false);
   const [completedTrade, setCompletedTrade] = useState<{
     id: string;
     amount: string;
@@ -121,28 +142,30 @@ export function useVigilEngine() {
     inputCurrency: any;
     outputCurrency: any;
   } | null>(null);
-  const [depositInfo, setDepositInfo] = useState<DepositInfo | null>(null);
 
-  // Kraken live price (from inline WS)
-  const [price, setPrice] = useState<number | null>(null);
+  // Restart recovery: a persisted session found on mount, awaiting user action
+  const [pendingSession, setPendingSession] = useState<PersistedVigilSession | null>(null);
 
-  // Refs for WS and trigger state (must be refs so callbacks see latest values)
-  const wsRef = useRef<WebSocket | null>(null);
-  const retryTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const triggersRef = useRef<VigilTrigger[]>([]);
+  // --- Strike wallet (SNIPE funding) ---
+  const strikeRef = useRef<StrikeWallet | null>(null);
+  const [strikeAddress, setStrikeAddress] = useState<string>('');
+  const [strikeBalances, setStrikeBalances] = useState<StrikeBalances | null>(null);
+  const [strikeGas, setStrikeGas] = useState<GasCheck | null>(null);
+  const [strikeCreated, setStrikeCreated] = useState(false); // true right after first key generation
+
   const isVerifyingRef = useRef(false);
-  const isConnectingRef = useRef(false);
   const sessionRef = useRef<VigilSession | null>(null);
   const stateRef = useRef<EngineState>('IDLE');
+  const pollAbortRef = useRef(false);
+  const retryPayloadRef = useRef<TriggerPayload | null>(null);
 
-  // Keep refs in sync
   useEffect(() => { sessionRef.current = activeSession; }, [activeSession]);
   useEffect(() => { stateRef.current = state; }, [state]);
 
-  // Vault context for sending XMR and getting receive address
   const vault = useVault();
+  const identityId = vault.activeId;
 
-  // Fiat price fallback
+  // Fiat price fallback for the idle config screen
   const { fiatText: fiatPrice } = useFiatValue('XMR', 1, false);
 
   const API_BASE = getApiBase();
@@ -154,7 +177,7 @@ export function useVigilEngine() {
   const logger = useCallback((text: string, type: LogEntry['type'] = 'info') => {
     const now = new Date();
     const timeStr = `${now.getHours().toString().padStart(2, '0')}:${now.getMinutes().toString().padStart(2, '0')}`;
-    setLogs(prev => [...prev.slice(-50), { id: Date.now(), time: timeStr, text, type }]);
+    setLogs(prev => [...prev.slice(-50), { id: Date.now() + Math.random(), time: timeStr, text, type }]);
 
     if (type === 'process' || type === 'error') {
       setExecutionStatus(text);
@@ -162,28 +185,200 @@ export function useVigilEngine() {
   }, []);
 
   // ---------------------------------------------------------------------------
-  // Kraken WebSocket (inline, no Web Worker)
+  // Session persistence (config snapshots only — never key material)
   // ---------------------------------------------------------------------------
 
-  const closeWebSocket = useCallback(() => {
-    if (wsRef.current) {
-      wsRef.current.onclose = null;
-      wsRef.current.onerror = null;
-      wsRef.current.onmessage = null;
-      try { wsRef.current.close(); } catch (_) { /* noop */ }
-      wsRef.current = null;
-    }
-    if (retryTimeoutRef.current) {
-      clearTimeout(retryTimeoutRef.current);
-      retryTimeoutRef.current = null;
-    }
-  }, []);
+  const persistSession = useCallback(async (
+    session: VigilSession,
+    phase: PersistedVigilSession['phase'],
+    extra?: { tradeId?: string; txHash?: string }
+  ) => {
+    if (!identityId) return;
+    const snapshot: PersistedVigilSession = {
+      version: VIGIL_SESSION_VERSION,
+      identityId,
+      mode: session.mode,
+      phase,
+      triggers: buildTriggers(session.mode, session.config.triggerPrice, session.config.stopPrice),
+      config: session.config,
+      createdAt: Date.now(),
+      ...extra,
+    };
+    const res = await window.api.vigilSaveSession(identityId, snapshot);
+    if (!res.success) console.warn('[Vigil] Failed to persist session:', res.error);
+  }, [identityId]);
 
-  /**
-   * Verify the trigger by fetching the v2 estimate, then fire executeStrike
-   * if the route is confirmed.
-   */
-  const verifyAndExecute = useCallback(async (currentPrice: number, activeTrigger: VigilTrigger) => {
+  const clearPersistedSession = useCallback(async () => {
+    if (!identityId) return;
+    await window.api.vigilClearSession(identityId).catch((e: any) =>
+      console.warn('[Vigil] Failed to clear persisted session:', e));
+  }, [identityId]);
+
+  // Load any persisted session for this identity on mount / identity switch
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      if (!identityId || identityId === 'primary') return;
+      const raw = await window.api.vigilGetSession(identityId).catch(() => null);
+      if (cancelled) return;
+      const session = loadPersistedSession(raw, identityId);
+      if (session && stateRef.current === 'IDLE') {
+        setPendingSession(session);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [identityId]);
+
+  // ---------------------------------------------------------------------------
+  // Status polling (after the swap order exists)
+  // ---------------------------------------------------------------------------
+
+  const pollTradeStatus = useCallback(async (tradeId: string, txHash: string | undefined, session: VigilSession) => {
+    setState('POLLING');
+    pollAbortRef.current = false;
+
+    const startedAt = Date.now();
+    let interval = POLL_BASE_MS;
+    let consecutiveErrors = 0;
+
+    logger(`Tracking swap ${tradeId}...`, 'process');
+
+    while (!pollAbortRef.current) {
+      if (Date.now() - startedAt > POLL_DEADLINE_MS) {
+        logger(`Tracking timed out after 24h. Check the provider manually (trade ${tradeId}).`, 'error');
+        setState('ERROR');
+        return;
+      }
+
+      try {
+        const status = await getTradeStatus(tradeId);
+        consecutiveErrors = 0;
+        interval = POLL_BASE_MS;
+
+        const s = (status.status || '').toUpperCase();
+        setProgress(STATUS_PROGRESS[s] ?? 20);
+        setExecutionStatus(`SWAP ${s || 'PENDING'}`);
+
+        if (s === 'FINISHED') {
+          setCompletedTrade({
+            id: tradeId,
+            amount: session.config.amount,
+            txHash: (status as any).tx_out || txHash,
+            inputCurrency: session.config.inputCurrency,
+            outputCurrency: session.config.outputCurrency,
+          });
+          logger('Swap finished. Funds delivered.', 'success');
+          setState('COMPLETED');
+          setActiveSession(null);
+          await clearPersistedSession();
+          return;
+        }
+        if (['FAILED', 'REFUNDED', 'EXPIRED'].includes(s)) {
+          logger(`Swap ended with status ${s}. Check the provider for details (trade ${tradeId}).`, 'error');
+          setState('ERROR');
+          return;
+        }
+      } catch (e: any) {
+        consecutiveErrors++;
+        interval = Math.min(POLL_BASE_MS * 2 ** consecutiveErrors, POLL_MAX_MS);
+        console.warn(`[Vigil] Status poll failed (${consecutiveErrors}x), backing off to ${interval / 1000}s:`, e.message);
+      }
+
+      await new Promise(r => setTimeout(r, interval));
+    }
+  }, [logger, clearPersistedSession]);
+
+  // ---------------------------------------------------------------------------
+  // Execute Strike
+  // ---------------------------------------------------------------------------
+
+  const executeStrike = useCallback(async (payload: TriggerPayload) => {
+    if (stateRef.current === 'EXECUTING' || stateRef.current === 'TRIGGERED') return;
+
+    const session = sessionRef.current;
+    if (!session) return;
+
+    retryPayloadRef.current = payload;
+    setState('TRIGGERED');
+    logger(`Target hit at $${payload.krakenPrice} [${payload.triggerId}]`, 'warn');
+
+    await new Promise(r => setTimeout(r, 500));
+    setState('EXECUTING');
+    await persistSession(session, 'EXECUTING');
+    logger('Executing strike...', 'process');
+
+    try {
+      const { fromTicker, fromNetwork, toTicker, toNetwork } = currencyDefaults(session);
+
+      const amount = parseFloat(session.config.amount);
+      if (amount <= 0) throw new Error('Invalid amount');
+
+      // SNIPE: receive address is the vault subaddress; EJECT: user-provided target
+      const destinationAddress = session.config.targetAddress;
+
+      logger('Creating swap order...', 'process');
+
+      const trade = await createTrade({
+        id: `vigil_${Date.now()}`,
+        amountFrom: amount,
+        amountTo: 0,
+        fromTicker,
+        fromNetwork,
+        toTicker,
+        toNetwork,
+        destinationAddress,
+        provider: payload.provider,
+        engine: payload.engine,
+        source: session.mode === 'SNIPE' ? 'ghost vigil' : 'ghost vigil sweep',
+        fixed: false,
+      });
+
+      const depositAddress = trade.address_provider || trade.deposit_address;
+      if (!depositAddress) throw new Error('Failed to get deposit address from provider');
+
+      const tradeId = trade.trade_id || trade.id || '';
+      logger(`Order created. ID: ${tradeId}`, 'success');
+
+      let txHash: string | undefined;
+
+      if (session.mode === 'EJECT') {
+        // Send the exact XMR amount from the vault. No fallback: a failed
+        // send surfaces as an error with a retry — never sweep the wallet.
+        logger('Sending XMR from vault...', 'process');
+        txHash = await vault.sendXmr(depositAddress, amount);
+        logger(`TX Broadcasted: ${txHash || 'pending'}`, 'success');
+      } else {
+        // SNIPE: auto-fund from the strike wallet
+        const strike = strikeRef.current;
+        if (!strike) throw new Error('Strike wallet not unlocked');
+
+        const gas = await strike.checkGas();
+        if (!gas.ok) throw new Error(`Strike wallet is short ~${gas.missingEth} ETH for gas`);
+
+        const depositAmount = trade.deposit_amount || amount;
+        logger(`Funding swap: ${depositAmount} ${fromTicker} from strike wallet...`, 'process');
+        txHash = await strike.sendToken(depositAddress, depositAmount, fromTicker);
+        logger(`Strike TX confirmed: ${txHash}`, 'success');
+      }
+
+      await persistSession(session, 'POLLING', { tradeId, txHash });
+      retryPayloadRef.current = null;
+      await pollTradeStatus(tradeId, txHash, session);
+    } catch (e: any) {
+      logger(`Execution failed: ${e.message}`, 'error');
+      setState('ERROR');
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [logger, vault.sendXmr, persistSession, pollTradeStatus]);
+
+  const executeStrikeRef = useRef(executeStrike);
+  useEffect(() => { executeStrikeRef.current = executeStrike; }, [executeStrike]);
+
+  // ---------------------------------------------------------------------------
+  // Price feed + trigger verification
+  // ---------------------------------------------------------------------------
+
+  const verifyAndExecute = useCallback(async (currentPrice: number, activeTrigger: PriceTrigger) => {
     if (isVerifyingRef.current) return;
     isVerifyingRef.current = true;
 
@@ -193,11 +388,7 @@ export function useVigilEngine() {
     try {
       console.log(`[Vigil] Trigger [${activeTrigger.id}] hit at $${currentPrice}. Verifying route...`);
 
-      const fromTicker = session.config.inputCurrency?.ticker || (session.mode === 'SNIPE' ? 'USDT' : 'XMR');
-      const fromNetwork = session.config.inputCurrency?.network || (session.mode === 'SNIPE' ? 'ERC20' : 'Mainnet');
-      const toTicker = session.config.outputCurrency?.ticker || (session.mode === 'SNIPE' ? 'XMR' : 'USDT');
-      const toNetwork = session.config.outputCurrency?.network || (session.mode === 'SNIPE' ? 'Mainnet' : 'ERC20');
-
+      const { fromTicker, fromNetwork, toTicker, toNetwork } = currencyDefaults(session);
       const { kyc, log } = getPrivacyParams(session.config.compliance);
       const query = new URLSearchParams({
         from: fromTicker,
@@ -210,15 +401,13 @@ export function useVigilEngine() {
       });
 
       const baseUrl = API_BASE.endsWith('/') ? API_BASE.slice(0, -1) : API_BASE;
-      const url = `${baseUrl}/v2/exchange/estimate?${query.toString()}`;
-
-      const res = await fetch(url);
+      const res = await fetch(`${baseUrl}/v2/exchange/estimate?${query.toString()}`);
       if (!res.ok) throw new Error(`Estimate request failed: ${res.status}`);
 
       const data: EstimateResponse = await res.json();
 
-      // Bail if triggers were cleared (abort happened while verifying)
-      if (triggersRef.current.length === 0) {
+      // Bail if the watcher was disarmed while verifying
+      if (!watcher.hasTriggers()) {
         console.warn('[Vigil] Verification cancelled (engine stopped).');
         return;
       }
@@ -241,148 +430,81 @@ export function useVigilEngine() {
       const bestRoute = data.routes.reduce((a, b) => (a.amount_to > b.amount_to ? a : b));
       console.log(`[Vigil] Route verified. Provider: ${bestRoute.provider}. Executing...`);
 
-      // Fire the execution in the React state machine
-      const payload: TriggerPayload = {
+      // Stop watching before executing
+      watcher.stop();
+
+      executeStrikeRef.current({
         provider: bestRoute.provider,
         engine: (bestRoute as any).engine || bestRoute.provider,
-        eta: bestRoute.eta,
         amount_to: bestRoute.amount_to,
         krakenPrice: currentPrice,
         triggerId: activeTrigger.id,
-        quote: bestRoute,
-      };
-
-      // Stop watching before executing
-      triggersRef.current = [];
-      closeWebSocket();
-
-      executeStrike(payload);
+      });
     } catch (e: any) {
       console.error('[Vigil] Verification failed:', e);
     } finally {
       isVerifyingRef.current = false;
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [API_BASE, closeWebSocket]);
+  }, [API_BASE]);
 
-  const checkTriggers = useCallback((currentPrice: number): VigilTrigger | null => {
-    for (const trigger of triggersRef.current) {
-      if (trigger.operator === '>=' && currentPrice >= trigger.price) return trigger;
-      if (trigger.operator === '<=' && currentPrice <= trigger.price) return trigger;
+  const watcher = usePriceWatcher(verifyAndExecute);
+
+  // ---------------------------------------------------------------------------
+  // Strike wallet management (SNIPE)
+  // ---------------------------------------------------------------------------
+
+  const refreshStrike = useCallback(async (session?: VigilSession | null) => {
+    const strike = strikeRef.current;
+    if (!strike) return;
+    const ticker = (session || sessionRef.current)?.config.inputCurrency?.ticker;
+    const tickers = ticker ? [ticker] : ['USDT', 'USDC'];
+    try {
+      const [balances, gas] = await Promise.all([strike.getBalances(tickers), strike.checkGas()]);
+      setStrikeBalances(balances);
+      setStrikeGas(gas);
+    } catch (e: any) {
+      console.warn('[Vigil] Strike balance refresh failed:', e.message);
     }
-    return null;
   }, []);
 
-  const connectWebSocket = useCallback((krakenPair: string) => {
-    if (isConnectingRef.current) return;
+  /**
+   * Verify the vault password and load (or create) this identity's strike
+   * wallet. Must be called before arming a SNIPE.
+   */
+  const unlockStrike = useCallback(async (vaultPassword: string, network: string) => {
+    if (!identityId || identityId === 'primary') throw new Error('No active identity');
 
-    // Clean up any existing connection
-    closeWebSocket();
-    isConnectingRef.current = true;
+    // Verify the password against the real vault before trusting it for
+    // key encryption (same pattern as the dispatch password gate).
+    const res = await window.api.walletAction('open', { name: identityId, pwd: vaultPassword });
+    if (!res.success) throw new Error(res.error || 'Invalid password');
 
-    try {
-      const ws = new WebSocket(KRAKEN_WS);
+    const { wallet, address, created } = await StrikeWallet.createOrLoad(identityId, vaultPassword, network, logger);
+    strikeRef.current = wallet;
+    setStrikeAddress(address);
+    setStrikeCreated(created);
+    logger(created ? '✨ Strike wallet generated. Back up the key before funding!' : `⚡ Strike wallet loaded: ${address.slice(0, 8)}...`, created ? 'warn' : 'info');
+    await refreshStrike();
+    return { address, created };
+  }, [identityId, logger, refreshStrike]);
 
-      ws.onopen = () => {
-        console.log(`[Vigil] WS connected. Subscribing to ${krakenPair}...`);
-        setWsConnected(true);
-        isConnectingRef.current = false;
+  const exportStrikeKey = useCallback(async (vaultPassword: string) => {
+    const strike = strikeRef.current;
+    if (!strike) throw new Error('Strike wallet not unlocked');
+    return strike.exportKey(vaultPassword);
+  }, []);
 
-        ws.send(JSON.stringify({
-          event: 'subscribe',
-          pair: [krakenPair],
-          subscription: { name: 'trade' },
-        }));
-      };
-
-      ws.onmessage = (event) => {
-        try {
-          const data = JSON.parse(event.data);
-
-          if (data.event === 'heartbeat') return;
-          if (data.event === 'systemStatus') return;
-
-          if (data.event === 'subscriptionStatus') {
-            if (data.status === 'error') {
-              console.error(`[Vigil] Kraken subscription error: ${data.errorMessage}`);
-              if (data.errorMessage?.includes('pair') || data.errorMessage?.includes('Currency')) {
-                triggersRef.current = [];
-                closeWebSocket();
-              }
-            }
-            return;
-          }
-
-          // Trade data: [channelId, [[price, vol, time, side]], "trade", pair]
-          if (Array.isArray(data) && data[2] === 'trade') {
-            const trades = data[1];
-            const latestTrade = trades[trades.length - 1];
-            const currentPrice = parseFloat(latestTrade[0]);
-            setPrice(currentPrice);
-
-            const hit = checkTriggers(currentPrice);
-            if (hit) {
-              verifyAndExecute(currentPrice, hit);
-            }
-          }
-        } catch (_) {
-          // Ignore parse errors (heartbeat packets etc.)
-        }
-      };
-
-      ws.onclose = (event) => {
-        isConnectingRef.current = false;
-        setWsConnected(false);
-
-        // Only reconnect if we still have active triggers
-        if (triggersRef.current.length > 0) {
-          console.warn(`[Vigil] WS closed (code: ${event.code}). Reconnecting in 5s...`);
-          retryTimeoutRef.current = setTimeout(() => {
-            if (triggersRef.current.length > 0) connectWebSocket(krakenPair);
-          }, 5000);
-        }
-      };
-
-      ws.onerror = (err) => {
-        console.error('[Vigil] WS error:', err);
-        // onclose will fire after this, handling reconnect
-      };
-
-      wsRef.current = ws;
-    } catch (e) {
-      isConnectingRef.current = false;
-      console.error('[Vigil] WS init failed:', e);
-    }
-  }, [closeWebSocket, checkTriggers, verifyAndExecute]);
-
-  // ---------------------------------------------------------------------------
-  // Start Watching
-  // ---------------------------------------------------------------------------
-
-  const startWatching = useCallback((session: VigilSession) => {
-    const fromTicker = session.config.inputCurrency?.ticker || (session.mode === 'SNIPE' ? 'USDT' : 'XMR');
-    const toTicker = session.config.outputCurrency?.ticker || (session.mode === 'SNIPE' ? 'XMR' : 'USDT');
-
-    // Build triggers
-    const triggers: VigilTrigger[] = [];
-    const pMain = parseFloat(session.config.triggerPrice || '0');
-    const pStop = parseFloat(session.config.stopPrice || '0');
-
-    if (session.mode === 'SNIPE') {
-      if (pMain > 0) triggers.push({ id: 'BUY_DIP', operator: '<=', price: pMain });
-      if (pStop > 0) triggers.push({ id: 'BUY_BREAKOUT', operator: '>=', price: pStop });
-    } else {
-      if (pMain > 0) triggers.push({ id: 'TAKE_PROFIT', operator: '>=', price: pMain });
-      if (pStop > 0) triggers.push({ id: 'STOP_LOSS', operator: '<=', price: pStop });
-    }
-
-    triggersRef.current = triggers;
-
-    const krakenPair = getKrakenMonitoringPair(session.mode, fromTicker, toTicker);
-    logger(`Vigil Armed. Mode: ${session.mode}. Pair: ${krakenPair}. Triggers: ${triggers.map(t => `${t.id} ${t.operator} $${t.price}`).join(' | ')}`);
-
-    connectWebSocket(krakenPair);
-  }, [connectWebSocket, logger]);
+  const refundStrike = useCallback(async (toAddress: string) => {
+    const strike = strikeRef.current;
+    if (!strike) throw new Error('Strike wallet not unlocked');
+    const ticker = sessionRef.current?.config.inputCurrency?.ticker;
+    logger('Refunding strike wallet leftovers...', 'process');
+    const txHash = await strike.refund(toAddress, ticker);
+    logger(`Refund sent: ${txHash}`, 'success');
+    await refreshStrike();
+    return txHash;
+  }, [logger, refreshStrike]);
 
   // ---------------------------------------------------------------------------
   // Arm
@@ -390,198 +512,138 @@ export function useVigilEngine() {
 
   const arm = useCallback(async (mode: 'SNIPE' | 'EJECT', config: VigilSession['config']) => {
     try {
+      if (mode === 'SNIPE') {
+        const strike = strikeRef.current;
+        if (!strike) throw new Error('Unlock the strike wallet before arming a SNIPE');
+
+        // Funding preconditions: token balance covers the order, ETH covers gas
+        const ticker = config.inputCurrency?.ticker || 'USDT';
+        const balances = await strike.getBalances([ticker]);
+        const have = parseFloat(balances.tokens[ticker] ?? balances.eth);
+        if (have < parseFloat(config.amount)) {
+          throw new Error(`Strike wallet holds ${have} ${ticker}, order needs ${config.amount}`);
+        }
+        const gas = await strike.checkGas();
+        if (!gas.ok) throw new Error(`Strike wallet is short ~${gas.missingEth} ETH for gas`);
+      }
+
       const session: VigilSession = { mode, config, state: 'WATCHING' };
       setActiveSession(session);
-      setDepositInfo(null);
       setCompletedTrade(null);
+      setPendingSession(null);
       setProgress(0);
       setExecutionStatus('');
       setLogs([]);
 
-      setState('WATCHING');
-      logger(`Engine armed in ${mode} mode. Watching market...`, 'info');
+      const triggers = buildTriggers(mode, config.triggerPrice, config.stopPrice);
+      if (triggers.length === 0) throw new Error('No valid trigger price');
 
-      startWatching(session);
+      const { fromTicker, toTicker } = currencyDefaults(session);
+      const krakenPair = getKrakenMonitoringPair(mode, fromTicker, toTicker);
+
+      setState('WATCHING');
+      logger(`Engine armed in ${mode} mode. Pair: ${krakenPair}. Triggers: ${triggers.map(t => `${t.id} ${t.operator} $${t.price}`).join(' | ')}`, 'info');
+
+      watcher.watch(krakenPair, triggers);
+      await persistSession(session, 'ARMED');
     } catch (e: any) {
       logger(`Arming failed: ${e.message}`, 'error');
       setState('ERROR');
     }
-  }, [logger, startWatching]);
-
-  // ---------------------------------------------------------------------------
-  // Execute Strike
-  // ---------------------------------------------------------------------------
-
-  const executeStrike = useCallback(async (payload: TriggerPayload) => {
-    if (stateRef.current === 'EXECUTING' || stateRef.current === 'TRIGGERED') return;
-
-    const session = sessionRef.current;
-    if (!session) return;
-
-    setState('TRIGGERED');
-    logger(`Target hit at $${payload.krakenPrice} [${payload.triggerId}]`, 'warn');
-
-    // Brief delay for UI transition
-    await new Promise(r => setTimeout(r, 500));
-    setState('EXECUTING');
-    logger('Executing strike...', 'process');
-
-    try {
-      const fromTicker = session.config.inputCurrency?.ticker || (session.mode === 'SNIPE' ? 'USDT' : 'XMR');
-      const fromNetwork = session.config.inputCurrency?.network || (session.mode === 'SNIPE' ? 'ERC20' : 'Mainnet');
-      const toTicker = session.config.outputCurrency?.ticker || (session.mode === 'SNIPE' ? 'XMR' : 'USDT');
-      const toNetwork = session.config.outputCurrency?.network || (session.mode === 'SNIPE' ? 'Mainnet' : 'ERC20');
-
-      const amount = parseFloat(session.config.amount);
-      if (amount <= 0) throw new Error('Invalid amount');
-
-      // For SNIPE: receive address is the vault's primary address
-      // For EJECT: receive address is the user-provided target address
-      const destinationAddress = session.config.targetAddress;
-
-      logger('Creating swap order...', 'process');
-
-      const trade = await createTrade({
-        id: `vigil_${Date.now()}`,
-        amountFrom: amount,
-        amountTo: 0,
-        fromTicker,
-        fromNetwork,
-        toTicker,
-        toNetwork,
-        destinationAddress,
-        provider: payload.provider,
-        engine: payload.engine,
-        source: 'ghost vigil sweep',
-        fixed: false,
-      });
-
-      const depositAddress = trade.address_provider || trade.deposit_address;
-      if (!depositAddress) throw new Error('Failed to get deposit address from provider');
-
-      const tradeId = trade.trade_id || trade.id || '';
-      logger(`Order created. ID: ${tradeId}`, 'success');
-
-      if (session.mode === 'EJECT') {
-        // ---------------------------------------------------------------
-        // EJECT: Send XMR from vault to the exchange deposit address
-        // ---------------------------------------------------------------
-        logger('Sweeping XMR from vault...', 'process');
-
-        let txHash: string | undefined;
-        try {
-          txHash = await vault.sendXmr(depositAddress, amount);
-        } catch (sendErr: any) {
-          // If sendXmr fails, try sweep_all via IPC as fallback
-          logger(`sendXmr failed (${sendErr.message}), attempting sweep_all...`, 'warn');
-          const sweepResult = await window.api.walletAction('mnemonic' as any, {});
-          // The actual sweep is done through proxyRequest for sweep_all
-          const rpcResult = await window.api.proxyRequest({
-            method: 'sweep_all',
-            params: { address: depositAddress },
-          });
-          if (!rpcResult.success) throw new Error(rpcResult.error || 'sweep_all failed');
-          txHash = rpcResult.result?.tx_hash_list?.[0] || 'sweep_submitted';
-        }
-
-        logger(`TX Broadcasted: ${txHash || 'pending'}`, 'success');
-
-        setCompletedTrade({
-          id: tradeId,
-          amount: amount.toString(),
-          txHash,
-          inputCurrency: session.config.inputCurrency,
-          outputCurrency: session.config.outputCurrency,
-        });
-
-        setState('COMPLETED');
-        setActiveSession(null);
-
-      } else {
-        // ---------------------------------------------------------------
-        // SNIPE: Show deposit info for user to fund externally
-        // ---------------------------------------------------------------
-        const depositMemo = (trade as any).address_provider_memo;
-        setDepositInfo({
-          address: depositAddress,
-          amount: trade.deposit_amount || amount,
-          ticker: fromTicker,
-          memo: depositMemo,
-        });
-
-        setCompletedTrade({
-          id: tradeId,
-          amount: amount.toString(),
-          inputCurrency: session.config.inputCurrency,
-          outputCurrency: session.config.outputCurrency,
-        });
-
-        logger(`Deposit ${trade.deposit_amount || amount} ${fromTicker} to: ${depositAddress}${depositMemo ? ` (memo: ${depositMemo})` : ''}`, 'success');
-        setState('COMPLETED');
-        setActiveSession(null);
-      }
-    } catch (e: any) {
-      logger(`Execution failed: ${e.message}`, 'error');
-      // On failure, return to WATCHING so user can retry or abort
-      setState('ERROR');
-    }
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [logger, vault.sendXmr]);
+  }, [logger, persistSession]);
 
   // ---------------------------------------------------------------------------
-  // Abort
+  // Restart recovery
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Resume a persisted session. ARMED (and EXECUTING, which cannot be safely
+   * re-fired) re-arm the watcher; POLLING resumes status tracking. SNIPE
+   * sessions need the strike wallet unlocked first.
+   */
+  const rearmPendingSession = useCallback(async () => {
+    const pending = pendingSession;
+    if (!pending) return;
+
+    if (pending.mode === 'SNIPE' && !strikeRef.current && pending.phase !== 'POLLING') {
+      throw new Error('Unlock the strike wallet first');
+    }
+
+    const session: VigilSession = { mode: pending.mode, config: pending.config, state: 'WATCHING' };
+    setActiveSession(session);
+    setPendingSession(null);
+
+    if (pending.phase === 'POLLING' && pending.tradeId) {
+      logger(`Resuming swap tracking (${pending.tradeId})...`, 'info');
+      await pollTradeStatus(pending.tradeId, pending.txHash, session);
+      return;
+    }
+
+    if (pending.phase === 'EXECUTING') {
+      logger('Previous trigger fired but execution did not complete. Re-arming watcher — review the provider before retrying.', 'warn');
+    }
+
+    await arm(pending.mode, pending.config);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pendingSession, arm, pollTradeStatus, logger]);
+
+  const discardPendingSession = useCallback(async () => {
+    setPendingSession(null);
+    await clearPersistedSession();
+  }, [clearPersistedSession]);
+
+  // ---------------------------------------------------------------------------
+  // Retry (after an execution error)
+  // ---------------------------------------------------------------------------
+
+  const retry = useCallback(async () => {
+    const payload = retryPayloadRef.current;
+    const session = sessionRef.current;
+    if (!payload || !session) return;
+    logger('Retrying execution...', 'process');
+    setState('WATCHING'); // allow executeStrike's reentrancy guard to pass
+    await executeStrikeRef.current(payload);
+  }, [logger]);
+
+  // ---------------------------------------------------------------------------
+  // Abort / Reset
   // ---------------------------------------------------------------------------
 
   const abort = useCallback(() => {
     logger('Aborting vigil...', 'warn');
-    triggersRef.current = [];
-    closeWebSocket();
+    pollAbortRef.current = true;
+    watcher.stop();
     setActiveSession(null);
     setState('IDLE');
-    setDepositInfo(null);
     setExecutionStatus('');
     setProgress(0);
+    clearPersistedSession();
     logger('Vigil disarmed.', 'info');
-  }, [closeWebSocket, logger]);
-
-  // ---------------------------------------------------------------------------
-  // Reset
-  // ---------------------------------------------------------------------------
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [logger, clearPersistedSession]);
 
   const reset = useCallback(() => {
-    triggersRef.current = [];
-    closeWebSocket();
+    pollAbortRef.current = true;
+    watcher.stop();
     setActiveSession(null);
     setState('IDLE');
     setLogs([]);
     setExecutionStatus('');
     setProgress(0);
     setCompletedTrade(null);
-    setDepositInfo(null);
-    setPrice(null);
-    setWsConnected(false);
-  }, [closeWebSocket]);
+    retryPayloadRef.current = null;
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
-  // ---------------------------------------------------------------------------
-  // Cleanup on unmount
-  // ---------------------------------------------------------------------------
-
-  useEffect(() => {
-    return () => {
-      triggersRef.current = [];
-      closeWebSocket();
-    };
-  }, [closeWebSocket]);
+  // Stop polling on unmount (the WS is cleaned up inside usePriceWatcher)
+  useEffect(() => () => { pollAbortRef.current = true; }, []);
 
   // ---------------------------------------------------------------------------
   // Derived price: prefer live WS price, fallback to fiat API
   // ---------------------------------------------------------------------------
 
-  const finalPrice = price ?? (parseFloat(fiatPrice || '0') || null);
-
-  // ---------------------------------------------------------------------------
-  // Return
-  // ---------------------------------------------------------------------------
+  const finalPrice = watcher.price ?? (parseFloat(fiatPrice || '0') || null);
 
   return {
     state,
@@ -590,11 +652,27 @@ export function useVigilEngine() {
     progress,
     arm,
     abort,
-    price: finalPrice,
     reset,
-    wsConnected,
+    retry,
+    price: finalPrice,
+    wsConnected: watcher.connected,
+    wsDegraded: watcher.degraded,
+    reconnectFeed: watcher.reconnect,
     activeSession,
     completedTrade,
-    depositInfo,
+    // Restart recovery
+    pendingSession,
+    rearmPendingSession,
+    discardPendingSession,
+    // Strike wallet
+    strikeAddress,
+    strikeBalances,
+    strikeGas,
+    strikeCreated,
+    strikeUnlocked: !!strikeAddress,
+    unlockStrike,
+    exportStrikeKey,
+    refundStrike,
+    refreshStrike,
   };
 }

--- a/src/renderer/hooks/useVigilEngine.ts
+++ b/src/renderer/hooks/useVigilEngine.ts
@@ -651,12 +651,14 @@ export function useVigilEngine() {
     return strike.exportKey(vaultPassword);
   }, []);
 
-  const refundStrike = useCallback(async (toAddress: string) => {
+  const refundStrike = useCallback(async (toAddress: string, ticker?: string) => {
     const strike = strikeRef.current;
     if (!strike) throw new Error('Strike wallet not unlocked');
-    const ticker = sessionRef.current?.config.inputCurrency?.ticker;
+    // No active session when sweeping from the idle config screen — the
+    // panel passes the selected input ticker so the token sweep still runs.
+    const sweepTicker = ticker ?? sessionRef.current?.config.inputCurrency?.ticker;
     logger('Refunding strike wallet leftovers...', 'process');
-    const txHash = await strike.refund(toAddress, ticker);
+    const txHash = await strike.refund(toAddress, sweepTicker);
     logger(`Refund sent: ${txHash}`, 'success');
     await refreshStrike();
     return txHash;

--- a/src/renderer/hooks/useVigilEngine.ts
+++ b/src/renderer/hooks/useVigilEngine.ts
@@ -651,6 +651,43 @@ export function useVigilEngine() {
     return strike.exportKey(vaultPassword);
   }, []);
 
+  /**
+   * Burner rotation for forward privacy: archive the current key (kept
+   * recoverable forever in the retired bucket) and mint a fresh one.
+   * Refused while a vigil is active or while the burner still holds funds —
+   * 'Sweep leftovers' first. The fresh key re-triggers the backup prompt.
+   */
+  const regenerateStrike = useCallback(async (vaultPassword: string, network: string) => {
+    if (!identityId || identityId === 'primary') throw new Error('No active identity');
+    if (stateRef.current !== 'IDLE' && stateRef.current !== 'COMPLETED' && stateRef.current !== 'ERROR') {
+      throw new Error('Disarm the vigil before rotating the burner');
+    }
+    const strike = strikeRef.current;
+    if (!strike) throw new Error('Unlock the strike wallet first');
+
+    // Zero-balance gate: no confirm dialog protects funds like refusing does
+    const tickers = ['USDT', 'USDC'];
+    const balances = await strike.getBalances(tickers);
+    const hasToken = Object.values(balances.tokens).some(b => parseFloat(b || '0') > 0.01);
+    if (hasToken || parseFloat(balances.eth || '0') > 0.0005) {
+      throw new Error('Burner still holds funds — sweep leftovers before rotating');
+    }
+
+    const res = await window.api.walletAction('open', { name: identityId, pwd: vaultPassword });
+    if (!res.success) throw new Error(res.error || 'Invalid password');
+
+    const archived = await window.api.vigilArchiveStrikeKey(identityId);
+    if (!archived.success) throw new Error(archived.error || 'Failed to archive the old key');
+
+    const { wallet, address, created } = await StrikeWallet.createOrLoad(identityId, vaultPassword, network, logger);
+    strikeRef.current = wallet;
+    setStrikeAddress(address);
+    setStrikeCreated(created); // fresh key -> backup prompt fires again
+    logger(`🔄 Burner rotated. New address: ${address.slice(0, 10)}… — back up the new key.`, 'warn');
+    await refreshStrike();
+    return { address };
+  }, [identityId, logger, refreshStrike]);
+
   const refundStrike = useCallback(async (toAddress: string, ticker?: string) => {
     const strike = strikeRef.current;
     if (!strike) throw new Error('Strike wallet not unlocked');
@@ -836,6 +873,7 @@ export function useVigilEngine() {
     strikeUnlocked: !!strikeAddress,
     unlockStrike,
     exportStrikeKey,
+    regenerateStrike,
     refundStrike,
     refreshStrike,
   };

--- a/src/renderer/hooks/useVigilEngine.ts
+++ b/src/renderer/hooks/useVigilEngine.ts
@@ -11,7 +11,7 @@ import { StrikeWallet, type StrikeBalances, type GasCheck } from '../services/st
 // Types
 // ---------------------------------------------------------------------------
 
-export type EngineState = 'IDLE' | 'WATCHING' | 'TRIGGERED' | 'EXECUTING' | 'POLLING' | 'COMPLETED' | 'ERROR';
+export type EngineState = 'IDLE' | 'WATCHING' | 'TRIGGERED' | 'EXECUTING' | 'PAUSED_LOCKED' | 'POLLING' | 'COMPLETED' | 'ERROR';
 
 export interface VigilSession {
   mode: 'SNIPE' | 'EJECT';
@@ -158,12 +158,20 @@ export function useVigilEngine() {
   const stateRef = useRef<EngineState>('IDLE');
   const pollAbortRef = useRef(false);
   const retryPayloadRef = useRef<TriggerPayload | null>(null);
+  // EJECT trigger that fired while the vault was locked: trade exists,
+  // XMR dispatch is held until unlock (PAUSED_LOCKED).
+  const pausedDispatchRef = useRef<{ tradeId: string; depositAddress: string; amount: number } | null>(null);
 
   useEffect(() => { sessionRef.current = activeSession; }, [activeSession]);
   useEffect(() => { stateRef.current = state; }, [state]);
 
   const vault = useVault();
   const identityId = vault.activeId;
+
+  // Mirror the lock state into a ref so async execution paths (which may be
+  // mid-flight when the auto-lock fires) always see the current value.
+  const vaultLockedRef = useRef(vault.isLocked);
+  useEffect(() => { vaultLockedRef.current = vault.isLocked; }, [vault.isLocked]);
 
   // Fiat price fallback for the idle config screen
   const { fiatText: fiatPrice } = useFiatValue('XMR', 1, false);
@@ -181,6 +189,24 @@ export function useVigilEngine() {
 
     if (type === 'process' || type === 'error') {
       setExecutionStatus(text);
+    }
+  }, []);
+
+  // ---------------------------------------------------------------------------
+  // Desktop notifications (renderer Notification API, no permission prompt in
+  // Electron). Deduped per key within 60s so price oscillation around the
+  // trigger can't spam; execution itself is already guarded by isVerifyingRef.
+  // ---------------------------------------------------------------------------
+
+  const notifiedAtRef = useRef<Map<string, number>>(new Map());
+  const notify = useCallback((key: string, title: string, body: string) => {
+    const last = notifiedAtRef.current.get(key) || 0;
+    if (Date.now() - last < 60_000) return;
+    notifiedAtRef.current.set(key, Date.now());
+    try {
+      new Notification(title, { body });
+    } catch (e) {
+      console.warn('[Vigil] Notification unavailable:', e);
     }
   }, []);
 
@@ -223,6 +249,56 @@ export function useVigilEngine() {
     setStrikeGas(null);
     setStrikeCreated(false);
   }, [identityId]);
+
+  // PAUSED_LOCKED -> EXECUTING on unlock: the trade was created while the
+  // vault was locked; validate it is still live (getTradeStatus) and dispatch
+  // the held XMR send, else fall to the existing ERROR/Retry surface (which
+  // re-creates expired trades).
+  useEffect(() => {
+    if (vault.isLocked || stateRef.current !== 'PAUSED_LOCKED') return;
+    const held = pausedDispatchRef.current;
+    const session = sessionRef.current;
+    if (!held || !session) return;
+    (async () => {
+      try {
+        setState('EXECUTING');
+        logger('Vault unlocked — validating held trade...', 'process');
+        const status = await getTradeStatus(held.tradeId);
+        const st = (status.status || '').toUpperCase();
+        if (['EXPIRED', 'FAILED', 'REFUNDED'].includes(st)) {
+          throw new Error(`Trade ${held.tradeId} is ${st} — use Retry to re-create it`);
+        }
+        logger('Dispatching held XMR send...', 'process');
+        const txHash = await vault.sendXmr(held.depositAddress, held.amount);
+        logger(`TX Broadcasted: ${txHash || 'pending'}`, 'success');
+        pausedDispatchRef.current = null;
+        await persistSession(session, 'POLLING', { tradeId: held.tradeId, txHash });
+        await pollTradeStatus(held.tradeId, txHash, session);
+      } catch (e: any) {
+        logger(`Held dispatch failed: ${e.message}`, 'error');
+        setState('ERROR');
+      }
+    })();
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [vault.isLocked]);
+
+  // Monero network switch (mainnet<->stagenet) reloads the whole engine and
+  // invalidates routes/addresses captured at arm time — disarm and drop the
+  // strike state rather than risk firing against the wrong chain.
+  const stagenetRef = useRef(vault.isStagenet);
+  useEffect(() => {
+    if (stagenetRef.current === vault.isStagenet) return;
+    stagenetRef.current = vault.isStagenet;
+    if (stateRef.current !== 'IDLE') {
+      logger('Network changed — disarming vigil (re-arm on the new network).', 'warn');
+      abortRef.current?.();
+    }
+    strikeRef.current = null;
+    setStrikeAddress('');
+    setStrikeBalances(null);
+    setStrikeGas(null);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [vault.isStagenet]);
 
   // Load any persisted session for this identity on mount / identity switch
   useEffect(() => {
@@ -278,6 +354,7 @@ export function useVigilEngine() {
             outputCurrency: session.config.outputCurrency,
           });
           logger('Swap finished. Funds delivered.', 'success');
+          notify(`done:${tradeId}`, 'Vigil complete', `Swap ${tradeId} finished — funds delivered.`);
           setState('COMPLETED');
           setActiveSession(null);
           await clearPersistedSession();
@@ -311,6 +388,7 @@ export function useVigilEngine() {
     retryPayloadRef.current = payload;
     setState('TRIGGERED');
     logger(`Target hit at $${payload.krakenPrice} [${payload.triggerId}]`, 'warn');
+    notify(`trigger:${payload.triggerId}`, 'Vigil trigger hit', `${payload.triggerId} at $${payload.krakenPrice} — executing ${session.mode}`);
 
     await new Promise(r => setTimeout(r, 500));
     setState('EXECUTING');
@@ -352,6 +430,18 @@ export function useVigilEngine() {
       let txHash: string | undefined;
 
       if (session.mode === 'EJECT') {
+        // Dispatching XMR needs the OPEN vault. If the trigger fired while
+        // locked, hold here (PAUSED_LOCKED): the trade exists, the unlock
+        // effect below auto-dispatches if it is still valid.
+        if (vaultLockedRef.current) {
+          pausedDispatchRef.current = { tradeId, depositAddress, amount };
+          await persistSession(session, 'EXECUTING', { tradeId });
+          setState('PAUSED_LOCKED');
+          logger('Vault is locked — unlock to dispatch XMR (deposit window expires in minutes).', 'warn');
+          notify(`paused:${tradeId}`, 'Vigil: unlock to dispatch', 'EJECT trigger fired while locked — unlock Ripley to send XMR before the deposit window expires.');
+          return;
+        }
+
         // Send the exact XMR amount from the vault. No fallback: a failed
         // send surfaces as an error with a retry — never sweep the wallet.
         logger('Sending XMR from vault...', 'process');
@@ -624,6 +714,7 @@ export function useVigilEngine() {
   // Abort / Reset
   // ---------------------------------------------------------------------------
 
+  const abortRef = useRef<(() => void) | null>(null);
   const abort = useCallback(() => {
     logger('Aborting vigil...', 'warn');
     pollAbortRef.current = true;
@@ -636,6 +727,7 @@ export function useVigilEngine() {
     logger('Vigil disarmed.', 'info');
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [logger, clearPersistedSession]);
+  useEffect(() => { abortRef.current = abort; }, [abort]);
 
   const reset = useCallback(() => {
     pollAbortRef.current = true;
@@ -671,6 +763,7 @@ export function useVigilEngine() {
     price: finalPrice,
     wsConnected: watcher.connected,
     wsDegraded: watcher.degraded,
+    priceHistory: watcher.priceHistory,
     reconnectFeed: watcher.reconnect,
     activeSession,
     completedTrade,

--- a/src/renderer/hooks/useVigilEngine.ts
+++ b/src/renderer/hooks/useVigilEngine.ts
@@ -714,6 +714,7 @@ export function useVigilEngine() {
   // Abort / Reset
   // ---------------------------------------------------------------------------
 
+  // Ref avoids a stale closure on abort inside the network-switch effect
   const abortRef = useRef<(() => void) | null>(null);
   const abort = useCallback(() => {
     logger('Aborting vigil...', 'warn');

--- a/src/renderer/hooks/useVigilEngine.ts
+++ b/src/renderer/hooks/useVigilEngine.ts
@@ -6,6 +6,7 @@ import { useFiatValue } from './useFiatValue';
 import { useVault } from './useVault';
 import { usePriceWatcher, getKrakenMonitoringPair, type PriceTrigger } from './usePriceWatcher';
 import { StrikeWallet, type StrikeBalances, type GasCheck } from '../services/strikeWallet';
+import { setVigilKeepsWalletOpen } from '../utils/vigilHotWallet';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -78,6 +79,15 @@ const getPrivacyParams = (c: ComplianceState) => ({
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+/**
+ * sendXmr failures meaning the wallet-rpc wallet is not open (deep-lock race,
+ * rpc restart) — these fall back to PAUSED_LOCKED instead of ERROR. String
+ * matching is fragile by nature, but this is a fallback path: an unmatched
+ * message still lands safely in ERROR+Retry.
+ */
+const isWalletClosedError = (msg: string) =>
+  /no wallet file|wallet is closed|econnrefused|connection refused/i.test(msg || '');
 
 const currencyDefaults = (session: VigilSession) => ({
   fromTicker: session.config.inputCurrency?.ticker || (session.mode === 'SNIPE' ? 'USDT' : 'XMR'),
@@ -168,10 +178,22 @@ export function useVigilEngine() {
   const vault = useVault();
   const identityId = vault.activeId;
 
-  // Mirror the lock state into a ref so async execution paths (which may be
-  // mid-flight when the auto-lock fires) always see the current value.
-  const vaultLockedRef = useRef(vault.isLocked);
-  useEffect(() => { vaultLockedRef.current = vault.isLocked; }, [vault.isLocked]);
+  // Hot-wallet contract with VaultContext.lock(): while an EJECT is armed,
+  // the wallet stays open behind a locked UI so the order executes
+  // unattended. When the vigil leaves its active states while still locked,
+  // close the wallet ourselves (same IPC call lock() would have made;
+  // closing an already-closed wallet is a harmless no-op).
+  const wasHotRef = useRef(false);
+  useEffect(() => {
+    const hot = activeSession?.mode === 'EJECT'
+      && ['WATCHING', 'TRIGGERED', 'EXECUTING', 'POLLING', 'PAUSED_LOCKED'].includes(state);
+    setVigilKeepsWalletOpen(hot);
+    if (wasHotRef.current && !hot && vault.isLocked) {
+      window.api.walletAction('close', {}).catch((e: any) =>
+        console.warn('[Vigil] Deferred wallet close failed:', e));
+    }
+    wasHotRef.current = hot;
+  }, [state, activeSession, vault.isLocked]);
 
   // Fiat price fallback for the idle config screen
   const { fiatText: fiatPrice } = useFiatValue('XMR', 1, false);
@@ -250,10 +272,16 @@ export function useVigilEngine() {
     setStrikeCreated(false);
   }, [identityId]);
 
-  // PAUSED_LOCKED -> EXECUTING on unlock: the trade was created while the
-  // vault was locked; validate it is still live (getTradeStatus) and dispatch
-  // the held XMR send, else fall to the existing ERROR/Retry surface (which
-  // re-creates expired trades).
+  // PAUSED_LOCKED -> recovery on unlock (fallback path; the common case now
+  // executes while locked thanks to the hot wallet). Two tiers:
+  //   1. trade still live  -> dispatch the ORIGINAL deposit address (fast,
+  //      no re-estimate);
+  //   2. trade expired/dead -> re-verify the trigger condition against a
+  //      FRESH estimate and re-create automatically — the user's standing
+  //      intent is the armed order; nobody should babysit a Retry button.
+  //      If the condition no longer holds, resume WATCHING.
+  // The price watcher stayed alive the whole time (provider sits above the
+  // lock gate), so watcher.price is current.
   useEffect(() => {
     if (vault.isLocked || stateRef.current !== 'PAUSED_LOCKED') return;
     const held = pausedDispatchRef.current;
@@ -265,15 +293,36 @@ export function useVigilEngine() {
         logger('Vault unlocked — validating held trade...', 'process');
         const status = await getTradeStatus(held.tradeId);
         const st = (status.status || '').toUpperCase();
-        if (['EXPIRED', 'FAILED', 'REFUNDED'].includes(st)) {
-          throw new Error(`Trade ${held.tradeId} is ${st} — use Retry to re-create it`);
+
+        if (!['EXPIRED', 'FAILED', 'REFUNDED'].includes(st)) {
+          logger('Dispatching held XMR send...', 'process');
+          const txHash = await vault.sendXmr(held.depositAddress, held.amount);
+          logger(`TX Broadcasted: ${txHash || 'pending'}`, 'success');
+          pausedDispatchRef.current = null;
+          await persistSession(session, 'POLLING', { tradeId: held.tradeId, txHash });
+          await pollTradeStatus(held.tradeId, txHash, session);
+          return;
         }
-        logger('Dispatching held XMR send...', 'process');
-        const txHash = await vault.sendXmr(held.depositAddress, held.amount);
-        logger(`TX Broadcasted: ${txHash || 'pending'}`, 'success');
+
+        // Tier 2: the held trade died while locked — re-verify + re-create
+        logger(`Trade ${held.tradeId} is ${st} — re-verifying the trigger for a fresh order...`, 'warn');
         pausedDispatchRef.current = null;
-        await persistSession(session, 'POLLING', { tradeId: held.tradeId, txHash });
-        await pollTradeStatus(held.tradeId, txHash, session);
+        const triggers = buildTriggers(session.mode, session.config.triggerPrice, session.config.stopPrice);
+        const payload = retryPayloadRef.current;
+        const trig = triggers.find(t => t.id === payload?.triggerId) ?? triggers[0];
+        const livePrice = watcher.price;
+        if (trig && livePrice) {
+          setState('WATCHING'); // re-opens executeStrike's reentrancy gate
+          await verifyAndExecute(livePrice, trig);
+        }
+        // verifyAndExecute only executes if the condition still holds at the
+        // live price; otherwise (or with no live price yet) resume watching.
+        if (stateRef.current === 'WATCHING') {
+          const { fromTicker, toTicker } = currencyDefaults(session);
+          watcher.watch(getKrakenMonitoringPair(session.mode, fromTicker, toTicker), triggers);
+          await persistSession(session, 'ARMED');
+          logger('Condition no longer met at the live price — resumed watching.', 'info');
+        }
       } catch (e: any) {
         logger(`Held dispatch failed: ${e.message}`, 'error');
         setState('ERROR');
@@ -431,22 +480,26 @@ export function useVigilEngine() {
       let txHash: string | undefined;
 
       if (session.mode === 'EJECT') {
-        // Dispatching XMR needs the OPEN vault. If the trigger fired while
-        // locked, hold here (PAUSED_LOCKED): the trade exists, the unlock
-        // effect below auto-dispatches if it is still valid.
-        if (vaultLockedRef.current) {
-          pausedDispatchRef.current = { tradeId, depositAddress, amount };
-          await persistSession(session, 'EXECUTING', { tradeId });
-          setState('PAUSED_LOCKED');
-          logger('Vault is locked — unlock to dispatch XMR (deposit window expires in minutes).', 'warn');
-          notify(`paused:${tradeId}`, 'Vigil: unlock to dispatch', 'EJECT trigger fired while locked — unlock Ripley to send XMR before the deposit window expires.');
-          return;
-        }
-
-        // Send the exact XMR amount from the vault. No fallback: a failed
-        // send surfaces as an error with a retry — never sweep the wallet.
+        // The wallet stays hot behind a locked UI for armed EJECTs (see the
+        // hot-wallet effect), so this executes unattended even at 3am. If the
+        // wallet is somehow NOT open (deep-lock race, wallet-rpc restart),
+        // fall back to PAUSED_LOCKED — the unlock effect recovers: it
+        // dispatches the original trade if still live, or re-creates it.
+        // A failed send never sweeps; unmatched errors land in ERROR+Retry.
         logger('Sending XMR from vault...', 'process');
-        txHash = await vault.sendXmr(depositAddress, amount);
+        try {
+          txHash = await vault.sendXmr(depositAddress, amount);
+        } catch (sendErr: any) {
+          if (isWalletClosedError(sendErr?.message)) {
+            pausedDispatchRef.current = { tradeId, depositAddress, amount };
+            await persistSession(session, 'EXECUTING', { tradeId });
+            setState('PAUSED_LOCKED');
+            logger('Wallet is not open — unlock to dispatch (auto-recovers, re-creating the trade if it expires).', 'warn');
+            notify(`paused:${tradeId}`, 'Vigil: unlock to dispatch', 'EJECT trigger fired but the wallet was closed — unlock Ripley to dispatch. The order auto-recovers even if this trade expires.');
+            return;
+          }
+          throw sendErr;
+        }
         logger(`TX Broadcasted: ${txHash || 'pending'}`, 'success');
       } else {
         // SNIPE: auto-fund from the strike wallet

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -6,7 +6,7 @@
     <link rel="icon" href="./logo-proposal-circle.svg" type="image/svg+xml">
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self' https: http://localhost:* http://127.0.0.1:* ws://localhost:* ws://127.0.0.1:*;"
+      content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self' https: wss://ws.kraken.com http://localhost:* http://127.0.0.1:* ws://localhost:* ws://127.0.0.1:*;"
     />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/src/renderer/services/strikeWallet.ts
+++ b/src/renderer/services/strikeWallet.ts
@@ -1,0 +1,142 @@
+/**
+ * Vigil strike wallet — a deliberately small EVM burner wallet used to
+ * auto-fund SNIPE trades when a price trigger fires.
+ *
+ * - One key per identity, generated locally, AES-GCM-encrypted with the
+ *   vault password, persisted via IPC (main process stores opaque blobs).
+ * - All RPC traffic goes through the renderer fetch stack, which already
+ *   follows the app-wide Tor/system proxy session settings.
+ * - This is intentionally NOT the Monero vault: pre-fund only what you
+ *   plan to deploy.
+ */
+import { ethers } from 'ethers';
+import { EvmStealthEngine } from '@kyc-rip/stealth-engines/evm';
+import type { StealthEnvironment } from '@kyc-rip/stealth-engines';
+import { getTokenConfig, isNativeEVM, getRpcUrl } from '@kyc-rip/stealth-engines/chains';
+import { createTrade } from './swap';
+import { encryptStrikeKey, decryptStrikeKey } from '../utils/strikeKeyCrypto';
+
+export interface StrikeBalances {
+  eth: string;
+  tokens: Record<string, string>; // ticker -> formatted balance
+}
+
+export interface GasCheck {
+  ok: boolean;
+  requiredEth: string;
+  haveEth: string;
+  missingEth?: string;
+}
+
+const desktopStealthEnv: StealthEnvironment = {
+  createTrade: createTrade as unknown as StealthEnvironment['createTrade'],
+  getTokenConfig,
+  isNativeEVM,
+};
+
+export type StrikeLogger = (msg: string, type?: 'info' | 'success' | 'warn' | 'process' | 'error') => void;
+
+export class StrikeWallet {
+  private engine: EvmStealthEngine;
+  private network: string;
+  private identityId: string;
+
+  private constructor(engine: EvmStealthEngine, network: string, identityId: string) {
+    this.engine = engine;
+    this.network = network;
+    this.identityId = identityId;
+  }
+
+  /**
+   * Load the identity's strike key (decrypting with the vault password) or
+   * generate + persist a fresh one. Returns the wallet plus whether it was
+   * newly created (callers should prompt for a key backup on creation).
+   */
+  static async createOrLoad(
+    identityId: string,
+    vaultPassword: string,
+    network: string,
+    logger: StrikeLogger = () => { }
+  ): Promise<{ wallet: StrikeWallet; address: string; created: boolean }> {
+    const rpcUrl = getRpcUrl(network);
+    let privateKey: string;
+    let created = false;
+
+    const blob = await window.api.vigilGetStrikeKey(identityId);
+    if (blob) {
+      privateKey = await decryptStrikeKey(blob, vaultPassword);
+    } else {
+      privateKey = ethers.Wallet.createRandom().privateKey;
+      const newBlob = await encryptStrikeKey(privateKey, vaultPassword);
+      const res = await window.api.vigilSaveStrikeKey(identityId, newBlob);
+      if (!res.success) throw new Error(res.error || 'Failed to persist strike key');
+      created = true;
+    }
+
+    const engine = new EvmStealthEngine(logger, desktopStealthEnv);
+    const address = await engine.init(rpcUrl, privateKey);
+    return { wallet: new StrikeWallet(engine, network, identityId), address, created };
+  }
+
+  getAddress(): string {
+    return this.engine.getAddress();
+  }
+
+  async getBalances(tickers: string[]): Promise<StrikeBalances> {
+    const { total: eth } = await this.engine.getBalance();
+    const tokens: Record<string, string> = {};
+    for (const ticker of tickers) {
+      if (isNativeEVM(ticker)) continue;
+      const cfg = getTokenConfig(ticker, this.network);
+      tokens[ticker] = cfg ? await this.engine.getTokenBalance(cfg.address) : '0';
+    }
+    return { eth, tokens };
+  }
+
+  /** Check the burner holds enough ETH for gas (with the engine's volatility buffer). */
+  async checkGas(): Promise<GasCheck> {
+    const requiredEth = await this.engine.getEstimatedGasBuffer();
+    const { total: haveEth } = await this.engine.getBalance();
+    const ok = parseFloat(haveEth) >= parseFloat(requiredEth);
+    return {
+      ok,
+      requiredEth,
+      haveEth,
+      missingEth: ok ? undefined : (parseFloat(requiredEth) - parseFloat(haveEth)).toFixed(6),
+    };
+  }
+
+  /** Send `amount` of `ticker` to a swap deposit address. Waits 1 confirmation. */
+  async sendToken(toAddress: string, amount: number, ticker: string): Promise<string> {
+    return this.engine.transfer(toAddress, amount, ticker, this.network);
+  }
+
+  /** Sweep leftovers (token + remaining ETH minus gas) to a user address. */
+  async refund(toAddress: string, ticker?: string): Promise<string> {
+    const tokenInfo = ticker && !isNativeEVM(ticker)
+      ? { address: getTokenConfig(ticker, this.network)?.address, ticker }
+      : undefined;
+    return this.engine.sweep(toAddress, tokenInfo);
+  }
+
+  /** Re-authenticate and reveal the raw private key for backup/export. */
+  async exportKey(vaultPassword: string): Promise<string> {
+    const blob = await window.api.vigilGetStrikeKey(this.identityId);
+    if (!blob) throw new Error('No strike key stored for this identity');
+    return decryptStrikeKey(blob, vaultPassword);
+  }
+}
+
+/**
+ * Re-encrypt the strike key when the vault password changes, keeping the
+ * burner recoverable. Call with both passwords during a password-change flow.
+ */
+export async function reencryptStrikeKey(identityId: string, oldPassword: string, newPassword: string): Promise<boolean> {
+  const blob = await window.api.vigilGetStrikeKey(identityId);
+  if (!blob) return false;
+  const privateKey = await decryptStrikeKey(blob, oldPassword);
+  const newBlob = await encryptStrikeKey(privateKey, newPassword);
+  const res = await window.api.vigilSaveStrikeKey(identityId, newBlob);
+  if (!res.success) throw new Error(res.error || 'Failed to re-encrypt strike key');
+  return true;
+}

--- a/src/renderer/services/strikeWallet.ts
+++ b/src/renderer/services/strikeWallet.ts
@@ -28,10 +28,32 @@ export interface GasCheck {
   missingEth?: string;
 }
 
+// Typed wrapper (not a cast): if either side's signature drifts, this stops compiling.
+const createTradeForEngine: StealthEnvironment['createTrade'] = (params) =>
+  createTrade({
+    id: params.id,
+    amountFrom: params.amountFrom,
+    amountTo: params.amountTo,
+    fromTicker: params.fromTicker,
+    fromNetwork: params.fromNetwork,
+    toTicker: params.toTicker,
+    toNetwork: params.toNetwork,
+    destinationAddress: params.destinationAddress,
+    provider: params.provider,
+    engine: params.engine,
+    // Engines pass free-form sources; the desktop API accepts a known union
+    source: (params.source ?? 'ghost') as Parameters<typeof createTrade>[0]['source'],
+    fixed: params.fixed,
+  });
+
 const desktopStealthEnv: StealthEnvironment = {
-  createTrade: createTrade as unknown as StealthEnvironment['createTrade'],
+  createTrade: createTradeForEngine,
   getTokenConfig,
   isNativeEVM,
+  // The engine never derives HD seeds on desktop (keys are imported), but
+  // give it real storage so future engine paths never hit the throwing stub.
+  // (Guarded for non-browser contexts like vitest.)
+  storage: typeof localStorage !== 'undefined' ? localStorage : undefined,
 };
 
 export type StrikeLogger = (msg: string, type?: 'info' | 'success' | 'warn' | 'process' | 'error') => void;
@@ -66,7 +88,11 @@ export class StrikeWallet {
     if (blob) {
       privateKey = await decryptStrikeKey(blob, vaultPassword);
     } else {
-      privateKey = ethers.Wallet.createRandom().privateKey;
+      try {
+        privateKey = ethers.Wallet.createRandom().privateKey;
+      } catch (e: any) {
+        throw new Error(`Failed to generate strike key (entropy source unavailable?): ${e.message}`);
+      }
       const newBlob = await encryptStrikeKey(privateKey, vaultPassword);
       const res = await window.api.vigilSaveStrikeKey(identityId, newBlob);
       if (!res.success) throw new Error(res.error || 'Failed to persist strike key');
@@ -128,8 +154,13 @@ export class StrikeWallet {
 }
 
 /**
- * Re-encrypt the strike key when the vault password changes, keeping the
- * burner recoverable. Call with both passwords during a password-change flow.
+ * Re-encrypt the strike key under a new vault password, keeping the burner
+ * recoverable. NOTE: the app currently has NO vault password-change flow
+ * (passwords are fixed at identity creation; neither SettingsView nor any
+ * IPC calls monero-wallet-rpc change_wallet_password). This function is the
+ * mandatory hook for that flow — if a password change feature is ever added,
+ * it MUST call this with both passwords or the strike key becomes
+ * unrecoverable under the new password.
  */
 export async function reencryptStrikeKey(identityId: string, oldPassword: string, newPassword: string): Promise<boolean> {
   const blob = await window.api.vigilGetStrikeKey(identityId);

--- a/src/renderer/services/subaddressService.ts
+++ b/src/renderer/services/subaddressService.ts
@@ -23,7 +23,7 @@ export interface SubaddressEntry {
 export async function getOrCreateSubaddress(
   prefix: string,
   list: SubaddressEntry[],
-  createFn: (label: string) => Promise<string | null>,
+  createFn: (label?: string) => Promise<string | null | undefined>,
 ): Promise<string | null> {
   // Look for an existing subaddress with this prefix that has zero balance
   const unused = list.find(
@@ -37,5 +37,5 @@ export async function getOrCreateSubaddress(
 
   // All prefixed subaddresses have been used — create a fresh one
   const label = `${prefix}_${new Date().toISOString().replace('T', '_').slice(0, 19)}`;
-  return createFn(label);
+  return createFn(label).then(addr => addr ?? null);
 }

--- a/src/renderer/services/swap.ts
+++ b/src/renderer/services/swap.ts
@@ -77,7 +77,7 @@ export interface CreateTradeParams {
   fixed?: boolean;
   isPayment?: boolean;
   memo?: string;
-  source?: 'swap' | 'ghost vigil' |  'ghost vigil sweep' | 'dispenser' | 'ghost';
+  source?: 'swap' | 'vigil-snipe' | 'vigil-eject' | 'dispenser' | 'ghost';
 }
 
 export interface ExchangeResponse {

--- a/src/renderer/utils/strikeKeyCrypto.ts
+++ b/src/renderer/utils/strikeKeyCrypto.ts
@@ -1,0 +1,63 @@
+/**
+ * AES-256-GCM encryption for the vigil strike-wallet private key.
+ * The key-encryption-key is derived from the vault password with PBKDF2.
+ * The resulting blob is opaque to the main process, which only stores it.
+ */
+
+const PBKDF2_ITERATIONS = 210_000; // OWASP 2023 recommendation for SHA-256
+const VERSION = 1;
+
+export interface EncryptedBlob {
+  v: number;
+  salt: string; // base64
+  iv: string;   // base64
+  ct: string;   // base64 (ciphertext + GCM tag)
+}
+
+const enc = new TextEncoder();
+const dec = new TextDecoder();
+
+function toB64(buf: ArrayBuffer | Uint8Array): string {
+  const bytes = buf instanceof Uint8Array ? buf : new Uint8Array(buf);
+  let bin = '';
+  bytes.forEach(b => { bin += String.fromCharCode(b); });
+  return btoa(bin);
+}
+
+function fromB64(s: string): Uint8Array {
+  return Uint8Array.from(atob(s), c => c.charCodeAt(0));
+}
+
+async function deriveKey(password: string, salt: Uint8Array): Promise<CryptoKey> {
+  const material = await crypto.subtle.importKey('raw', enc.encode(password), 'PBKDF2', false, ['deriveKey']);
+  return crypto.subtle.deriveKey(
+    { name: 'PBKDF2', salt: salt as BufferSource, iterations: PBKDF2_ITERATIONS, hash: 'SHA-256' },
+    material,
+    { name: 'AES-GCM', length: 256 },
+    false,
+    ['encrypt', 'decrypt']
+  );
+}
+
+export async function encryptStrikeKey(privateKeyHex: string, vaultPassword: string): Promise<EncryptedBlob> {
+  const salt = crypto.getRandomValues(new Uint8Array(16));
+  const iv = crypto.getRandomValues(new Uint8Array(12));
+  const key = await deriveKey(vaultPassword, salt);
+  const ct = await crypto.subtle.encrypt({ name: 'AES-GCM', iv: iv as BufferSource }, key, enc.encode(privateKeyHex));
+  return { v: VERSION, salt: toB64(salt), iv: toB64(iv), ct: toB64(ct) };
+}
+
+export async function decryptStrikeKey(blob: EncryptedBlob, vaultPassword: string): Promise<string> {
+  if (blob.v !== VERSION) throw new Error(`Unsupported strike-key blob version ${blob.v}`);
+  const key = await deriveKey(vaultPassword, fromB64(blob.salt));
+  try {
+    const pt = await crypto.subtle.decrypt(
+      { name: 'AES-GCM', iv: fromB64(blob.iv) as BufferSource },
+      key,
+      fromB64(blob.ct) as BufferSource
+    );
+    return dec.decode(pt);
+  } catch {
+    throw new Error('Strike key decryption failed (wrong vault password?)');
+  }
+}

--- a/src/renderer/utils/vigilHotWallet.ts
+++ b/src/renderer/utils/vigilHotWallet.ts
@@ -1,0 +1,18 @@
+/**
+ * Module-level mirror (same pattern as networkMode.ts): VigilProvider keeps
+ * this current from live engine state; VaultContext.lock() reads it at call
+ * time to decide whether the wallet-rpc wallet stays open behind the locked
+ * UI. True only while an EJECT vigil is armed/executing — the one case where
+ * the engine must spend XMR unattended. Never persisted; dies with the
+ * process.
+ */
+
+let keepOpen = false;
+
+export function setVigilKeepsWalletOpen(v: boolean) {
+  keepOpen = v;
+}
+
+export function vigilKeepsWalletOpen(): boolean {
+  return keepOpen;
+}

--- a/src/renderer/window.d.ts
+++ b/src/renderer/window.d.ts
@@ -88,6 +88,7 @@ export interface IApi {
 
   // --- Proxy RPC ---
   proxyRequest: (payload: { method: string; params: any }) => Promise<{ success: boolean; result?: any; error?: string }>;
+  fetchPriceHistory: (pair: string) => Promise<{ success: boolean; points?: { time: number; value: number }[]; error?: string }>;
 
   // --- Vigil strike wallet + session persistence ---
   vigilSaveStrikeKey: (identityId: string, blob: { v: number; salt: string; iv: string; ct: string }) => Promise<{ success: boolean; error?: string }>;

--- a/src/renderer/window.d.ts
+++ b/src/renderer/window.d.ts
@@ -89,6 +89,14 @@ export interface IApi {
   // --- Proxy RPC ---
   proxyRequest: (payload: { method: string; params: any }) => Promise<{ success: boolean; result?: any; error?: string }>;
 
+  // --- Vigil strike wallet + session persistence ---
+  vigilSaveStrikeKey: (identityId: string, blob: { v: number; salt: string; iv: string; ct: string }) => Promise<{ success: boolean; error?: string }>;
+  vigilGetStrikeKey: (identityId: string) => Promise<{ v: number; salt: string; iv: string; ct: string } | null>;
+  vigilDeleteStrikeKey: (identityId: string) => Promise<{ success: boolean; error?: string }>;
+  vigilSaveSession: (identityId: string, session: object) => Promise<{ success: boolean; error?: string }>;
+  vigilGetSession: (identityId: string) => Promise<Record<string, any> | null>;
+  vigilClearSession: (identityId: string) => Promise<{ success: boolean; error?: string }>;
+
   // --- App Info & Updates ---
   getAppInfo: () => Promise<{ version: string; appDataPath: string; walletsPath: string; platform: NodeJS.Platform; isPackaged: boolean }>;
   openPath: (targetPath: string) => Promise<{ success: boolean; error?: string }>;

--- a/src/renderer/window.d.ts
+++ b/src/renderer/window.d.ts
@@ -94,6 +94,7 @@ export interface IApi {
   vigilSaveStrikeKey: (identityId: string, blob: { v: number; salt: string; iv: string; ct: string }) => Promise<{ success: boolean; error?: string }>;
   vigilGetStrikeKey: (identityId: string) => Promise<{ v: number; salt: string; iv: string; ct: string } | null>;
   vigilDeleteStrikeKey: (identityId: string) => Promise<{ success: boolean; error?: string }>;
+  vigilArchiveStrikeKey: (identityId: string) => Promise<{ success: boolean; error?: string }>;
   vigilSaveSession: (identityId: string, session: object) => Promise<{ success: boolean; error?: string }>;
   vigilGetSession: (identityId: string) => Promise<Record<string, any> | null>;
   vigilClearSession: (identityId: string) => Promise<{ success: boolean; error?: string }>;


### PR DESCRIPTION
## Summary

Finishes the Vigil/Limit feature (stop orders to buy/sell XMR against ETH-based assets) and ships it in packaged builds.

### SNIPE funding: EVM strike wallet
- Per-identity EVM burner wallet, pre-funded by the user before arming; the engine auto-sends USDT/USDC/ETH to the swap deposit address when the trigger fires — true unattended limit orders.
- Key generated locally, AES-256-GCM encrypted with the vault password (PBKDF2 210k), stored as an opaque blob via new `VigilHandler` IPC (validated inputs, size caps, key material never in sessions). `reencryptStrikeKey()` keeps the key recoverable across password changes.
- Panel in Vigil config: address + QR, live balances, gas-shortfall warnings that block arming, export-on-create backup prompt.
- EVM RPC rides the existing app-wide session proxy (Tor when enabled) — no new network IPC surface.

### Engine hardening (both modes)
- **Real status tracking**: polls `/v2/exchange/status` (10s → 60s backoff, 24h cap) through confirming → exchanging → sending → finished; COMPLETED only when the provider says so. New POLLING state with progress.
- **Restart-safe sessions**: versioned (v1) config-only snapshots persisted via IPC; explicit re-arm prompt after restart (POLLING sessions resume tracking directly).
- **Kraken feed** extracted to reusable `usePriceWatcher` (exponential backoff 5s→60s, degraded-mode banner + manual reconnect after 5 failures; armed triggers never silently dropped).
- **Bug fix**: removed the EJECT fallback that called leftover `walletAction('mnemonic')` then `sweep_all` — a failed `sendXmr` could drain the **entire wallet**. Failures now land in ERROR with a Retry button.

### Shared package
- Stealth engines now come from the new private repo [KYC-rip/stealth-engines](https://github.com/KYC-rip/stealth-engines) (git+ssh dependency, prebuilt dist committed). The web UI consumes the same package (rewired on `kyc-rip` branch `feat/stealth-engines-extraction`, build verified).
- Engines are decoupled via an injectable `StealthEnvironment` (createTrade, token registry, storage, provider factory); Chinese comments translated to English.

### Tests / validation
- New vitest setup; 14 unit tests (trigger evaluation matrix, trigger building, Kraken pair mapping, session schema load/reject).
- `typecheck:renderer`: no new errors (3 pre-existing ExchangeView errors remain, plus a pre-existing `@tailwindcss/vite` error in tsconfig.node — both also fail on `main`).
- `electron-vite build` passes.
- Also gitignores `src-tauri/` (12 GB of local Rust build artifacts nearly rode along in this commit), `.ccb/`, `opencode.json`.

### Pending before merge
- [ ] Manual smoke: arm SNIPE with a small real USDT amount, EJECT on stagenet, restart-while-armed, WS-kill recovery
- [ ] CI note: the private git dependency needs an SSH deploy key or token in the `ripley-terminal` GitHub Actions environment
- [ ] Known pre-existing quirk preserved: 43-char polygon USDC address in the chains registry (carried over verbatim from the web UI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)