### PR TITLE
feat: FCMP++ stressnet mode + faucet (Mission 2)

### DIFF
--- a/docs/fcmp-stressnet-vps.md
+++ b/docs/fcmp-stressnet-vps.md
@@ -1,0 +1,267 @@
+# FCMP++ Stressnet VPS Setup
+
+Runbook for the dedicated VPS that serves the FCMP++ stressnet: a
+`seraphis-migration/monero` stressnet daemon (public restricted RPC) plus a
+faucet `monero-wallet-rpc` exposed only through a Cloudflare Access tunnel,
+consumed by the `kyc-rip-api` Worker route `POST /v1/faucet/stressnet/claim`.
+
+> **SECURITY — risk acceptance**
+> This VPS and the faucet wallet are **testnet-only**. They must **never**
+> hold, receive, or touch mainnet funds, mainnet wallet files, or mainnet
+> seeds. The wallet RPC runs with `--disable-rpc-login` and the box is
+> treated as disposable: assume full compromise is survivable because the
+> only thing at stake is worthless tXMR. Do not reuse this host, its SSH
+> keys, or its Cloudflare tunnel for anything that handles real value.
+
+## 1. Sizing
+
+| Resource | Requirement |
+|----------|-------------|
+| Disk     | < 10 GB (stressnet chain is small; budget headroom for resyncs) |
+| RAM      | 2 GB |
+| CPU      | 1–2 vCPU is plenty |
+| OS       | Debian 12 / Ubuntu 24.04 LTS (systemd assumed below) |
+
+## 2. Download the pinned stressnet release
+
+Binaries come from the Seraphis migration fork, **not** upstream monero.
+Browse <https://github.com/seraphis-migration/monero/releases> and pin the
+**latest beta tag** (do not track "latest" blindly — record the exact tag
+here once chosen, and only move it deliberately).
+
+```bash
+# Example — replace <TAG> with the pinned beta tag from the releases page.
+STRESSNET_TAG="<TAG>"
+cd /tmp
+curl -LO "https://github.com/seraphis-migration/monero/releases/download/${STRESSNET_TAG}/monero-linux-x64-${STRESSNET_TAG}.tar.bz2"
+# Verify the checksum/signature published on the release page before unpacking.
+tar xjf "monero-linux-x64-${STRESSNET_TAG}.tar.bz2"
+sudo install -m 0755 monero-*/monerod monero-*/monero-wallet-rpc monero-*/monero-wallet-cli /usr/local/bin/
+```
+
+Create the runtime directories:
+
+```bash
+sudo useradd --system --home /var/lib/monero-stressnet --shell /usr/sbin/nologin monero-stressnet
+sudo mkdir -p /var/lib/monero-stressnet /etc/monero-stressnet
+sudo chown monero-stressnet:monero-stressnet /var/lib/monero-stressnet
+```
+
+## 3. systemd: `monerod-stressnet.service`
+
+`/etc/systemd/system/monerod-stressnet.service`:
+
+```ini
+[Unit]
+Description=FCMP++ stressnet daemon (seraphis-migration/monero)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+User=monero-stressnet
+Group=monero-stressnet
+Type=simple
+ExecStart=/usr/local/bin/monerod \
+    --testnet \
+    --non-interactive \
+    --data-dir /var/lib/monero-stressnet \
+    --rpc-restricted-bind-ip 0.0.0.0 \
+    --rpc-restricted-bind-port 28089 \
+    --confirm-external-bind
+Restart=on-failure
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target
+```
+
+> **IMPORTANT:** the pinned release's README typically mandates extra flags
+> for the stressnet — seed nodes (`--add-exclusive-node` / `--seed-node`),
+> a custom network ID, or hard-fork height overrides. Copy those flags
+> verbatim from the pinned tag's README into `ExecStart` above. The
+> stressnet will not sync without them.
+
+The unrestricted RPC defaults to `127.0.0.1:28081` under `--testnet`; the
+faucet wallet uses that loopback port.
+
+## 4. systemd: `faucet-wallet-rpc.service`
+
+Create the faucet wallet once (testnet):
+
+```bash
+sudo -u monero-stressnet /usr/local/bin/monero-wallet-cli --testnet \
+    --generate-new-wallet /var/lib/monero-stressnet/faucet \
+    --daemon-address 127.0.0.1:28081
+```
+
+Store the wallet password in a root-only file:
+
+```bash
+sudo install -m 0600 -o root -g root /dev/null /etc/monero-stressnet/faucet.pass
+# then write the password into it (single line, no trailing newline needed)
+sudo nano /etc/monero-stressnet/faucet.pass
+```
+
+`/etc/systemd/system/faucet-wallet-rpc.service`:
+
+```ini
+[Unit]
+Description=FCMP++ stressnet faucet wallet RPC
+After=monerod-stressnet.service
+Requires=monerod-stressnet.service
+
+[Service]
+# Runs as root so it can read the 0600 root:root password file; the
+# wallet only ever holds tXMR (see risk acceptance at the top).
+User=root
+Type=simple
+ExecStart=/usr/local/bin/monero-wallet-rpc \
+    --testnet \
+    --rpc-bind-ip 127.0.0.1 \
+    --rpc-bind-port 28088 \
+    --wallet-file /var/lib/monero-stressnet/faucet \
+    --password-file /etc/monero-stressnet/faucet.pass \
+    --daemon-address 127.0.0.1:28081 \
+    --disable-rpc-login
+Restart=on-failure
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target
+```
+
+> **Why `--disable-rpc-login` is safe here:** the wallet RPC binds to
+> loopback only and is reachable from outside exclusively through the
+> cloudflared tunnel, which enforces a Cloudflare Access **service token**
+> in front of it (section 5). Auth happens at the Access layer; adding RPC
+> digest auth on top would just mean a second credential to rotate inside
+> the Workers env for no extra boundary. Nothing on the public interface
+> can reach port 28088 (section 7).
+
+Enable both units:
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable --now monerod-stressnet faucet-wallet-rpc
+```
+
+## 5. cloudflared tunnel (faucet RPC only)
+
+Install `cloudflared`, authenticate, and create a tunnel that exposes
+**only** the wallet RPC on loopback — the stressnet daemon RPC (28089) is
+served directly, not through the tunnel.
+
+```bash
+cloudflared tunnel login
+cloudflared tunnel create stressnet-faucet
+```
+
+`/etc/cloudflared/config.yml`:
+
+```yaml
+tunnel: stressnet-faucet
+credentials-file: /root/.cloudflared/<TUNNEL_UUID>.json
+
+ingress:
+  - hostname: stressnet-faucet.kyc.rip
+    service: http://127.0.0.1:28088
+  - service: http_status:404
+```
+
+```bash
+cloudflared tunnel route dns stressnet-faucet stressnet-faucet.kyc.rip
+sudo cloudflared service install
+sudo systemctl enable --now cloudflared
+```
+
+In the Cloudflare Zero Trust dashboard:
+
+1. Create a **service token** (Access → Service Auth → Service Tokens),
+   e.g. `stressnet-faucet-worker`.
+2. Create an **Access application** for `stressnet-faucet.kyc.rip` with a
+   policy of action **Service Auth** that allows only that service token.
+
+Record the token into the Workers env (names match the faucet route in
+`api/src/routes/faucet.ts` — the same pair already used for the mainnet
+wallet proxy):
+
+```bash
+cd kyc-rip/api
+npx wrangler secret put CF_ACCESS_CLIENT_ID      # token Client ID
+npx wrangler secret put CF_ACCESS_CLIENT_SECRET  # token Client Secret
+npx wrangler secret put FAUCET_RPC_URL           # https://stressnet-faucet.kyc.rip/json_rpc
+npx wrangler secret put FAUCET_ENABLED           # 'true' to open the faucet
+npx wrangler secret put FAUCET_EPOCH             # '1' initially; bump on chain wipes
+```
+
+> If the mainnet wallet proxy and the faucet end up behind **different**
+> Access applications, allow the same service token in both apps so one
+> credential pair serves both upstreams.
+
+## 6. Recovery after a stressnet chain reset
+
+Stressnets get wiped. When the pinned release announces a reset (or the
+chain forks unrecoverably):
+
+```bash
+# 1. Stop services
+sudo systemctl stop faucet-wallet-rpc monerod-stressnet
+
+# 2. Wipe the chain data (keep the wallet files!)
+sudo rm -rf /var/lib/monero-stressnet/testnet
+#    NOTE: do NOT delete /var/lib/monero-stressnet/faucet* (wallet + keys).
+#    If the reset ships new binaries, reinstall per section 2 first.
+
+# 3. Resync
+sudo systemctl start monerod-stressnet
+#    wait until synced: monerod --testnet status
+
+# 4. Rescan the wallet against the fresh chain
+sudo systemctl start faucet-wallet-rpc
+curl -s http://127.0.0.1:28088/json_rpc -d \
+  '{"jsonrpc":"2.0","id":"0","method":"rescan_blockchain"}' \
+  -H 'Content-Type: application/json'
+```
+
+Then **bump `FAUCET_EPOCH`** in the Workers env (e.g. `1` → `2`). The
+faucet keys all per-address/per-IP/daily counters under
+`faucet:${FAUCET_EPOCH}:…`, so bumping the epoch resets "one claim per
+address ever" — necessary because every address's claim is meaningless on
+the new chain.
+
+```bash
+cd kyc-rip/api && npx wrangler secret put FAUCET_EPOCH   # new value, e.g. '2'
+```
+
+## 7. Firewall
+
+```bash
+# Public stressnet RPC for wallet clients
+sudo ufw allow 28089/tcp comment 'stressnet restricted RPC'
+# Wallet RPC must never be reachable directly — loopback + tunnel only
+sudo ufw deny 28088/tcp comment 'faucet wallet RPC (cloudflared only)'
+# P2P (testnet default 28080) — allow so the daemon can peer
+sudo ufw allow 28080/tcp comment 'stressnet p2p'
+sudo ufw enable
+```
+
+Alternatively, serve the restricted RPC as a **Tor hidden service** instead
+of (or in addition to) clearnet 28089 — point the HS at
+`127.0.0.1:28089` in `torrc` and skip the public allow rule.
+
+## 8. Sanity checks
+
+```bash
+# Daemon synced?
+curl -s http://127.0.0.1:28081/json_rpc -d '{"jsonrpc":"2.0","id":"0","method":"get_info"}' -H 'Content-Type: application/json' | head -c 400
+
+# Wallet reachable + funded? (unlocked_balance in piconero)
+curl -s http://127.0.0.1:28088/json_rpc -d '{"jsonrpc":"2.0","id":"0","method":"get_balance","params":{"account_index":0}}' -H 'Content-Type: application/json'
+
+# End-to-end via the Worker
+curl -s https://api.kyc.rip/v1/faucet/stressnet/health
+```
+
+Fund the faucet wallet with mined/donated tXMR; the Worker refuses to
+dispense below 1.5 tXMR unlocked (`EXHAUSTED`) and pays out 0.5 tXMR per
+claim, capped at 5 tXMR per UTC day globally.

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "predev": "npm run setup-bins",
     "prestart": "npm run setup-bins",
     "deploy:public": "cd .. && ./deploy-public.sh",
-    "deploy:subtree": "cd .. && git subtree push --prefix desktop git@github-xbtoshi:KYC-rip/ghost-terminal.git main"
+    "deploy:subtree": "cd .. && git subtree push --prefix desktop git@github-xbtoshi:KYC-rip/ghost-terminal.git main",
+    "test": "vitest run"
   },
   "build": {
     "publish": [
@@ -105,7 +106,8 @@
     "postcss": "8.5.6",
     "tailwindcss": "4.1.18",
     "typescript": "5.9.3",
-    "vite": "7.3.1"
+    "vite": "7.3.1",
+    "vitest": "^4.1.8"
   },
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -108,6 +108,9 @@ importers:
       vite:
         specifier: 7.3.1
         version: 7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)
+      vitest:
+        specifier: ^4.1.8
+        version: 4.1.8(@types/node@25.2.3)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2))
 
 packages:
 
@@ -719,66 +722,79 @@ packages:
     resolution: {integrity: sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.59.0':
     resolution: {integrity: sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.59.0':
     resolution: {integrity: sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.59.0':
     resolution: {integrity: sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.59.0':
     resolution: {integrity: sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.59.0':
     resolution: {integrity: sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.59.0':
     resolution: {integrity: sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.59.0':
     resolution: {integrity: sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.59.0':
     resolution: {integrity: sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.59.0':
     resolution: {integrity: sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.59.0':
     resolution: {integrity: sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.59.0':
     resolution: {integrity: sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.59.0':
     resolution: {integrity: sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.59.0':
     resolution: {integrity: sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==}
@@ -813,6 +829,9 @@ packages:
   '@sindresorhus/is@4.6.0':
     resolution: {integrity: sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==}
     engines: {node: '>=10'}
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
   '@szmarczak/http-timer@4.0.6':
     resolution: {integrity: sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==}
@@ -856,24 +875,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.1.18':
     resolution: {integrity: sha512-1px92582HkPQlaaCkdRcio71p8bc8i/ap5807tPRDK/uw953cauQBT8c5tVGkOwrHMfc2Yh6UuxaH4vtTjGvHg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.1.18':
     resolution: {integrity: sha512-v3gyT0ivkfBLoZGF9LyHmts0Isc8jHZyVcbzio6Wpzifg/+5ZJpDiRiUhDLkcr7f/r38SWNe7ucxmGW3j3Kb/g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.1.18':
     resolution: {integrity: sha512-bhJ2y2OQNlcRwwgOAGMY0xTFStt4/wyU6pvI6LSuZpRgKQwxTec0/3Scu91O8ir7qCR3AuepQKLU/kX99FouqQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.1.18':
     resolution: {integrity: sha512-LffYTvPjODiP6PT16oNeUQJzNVyJl1cjIebq/rWWBF+3eDst5JGEFSc5cWxyRCJ0Mxl+KyIkqRxk1XPEs9x8TA==}
@@ -927,8 +950,14 @@ packages:
   '@types/cacheable-request@6.0.3':
     resolution: {integrity: sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==}
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
   '@types/debug@4.1.12':
     resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
@@ -1040,12 +1069,42 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@vitejs/plugin-react@4.7.0':
     resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
+
+  '@vitest/expect@4.1.8':
+    resolution: {integrity: sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==}
+
+  '@vitest/mocker@4.1.8':
+    resolution: {integrity: sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.8':
+    resolution: {integrity: sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==}
+
+  '@vitest/runner@4.1.8':
+    resolution: {integrity: sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg==}
+
+  '@vitest/snapshot@4.1.8':
+    resolution: {integrity: sha512-acfZboRmAIf05DEKcBQy33VXojFJjtUdLyo7oOmV9kebb2xdU01UknNiPuPZoJZQyO7DF0gZdTGTpeAzET9QPQ==}
+
+  '@vitest/spy@4.1.8':
+    resolution: {integrity: sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA==}
+
+  '@vitest/utils@4.1.8':
+    resolution: {integrity: sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==}
 
   '@xmldom/xmldom@0.8.11':
     resolution: {integrity: sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==}
@@ -1141,6 +1200,10 @@ packages:
 
   assert@2.1.0:
     resolution: {integrity: sha512-eLHpSK/Y4nhMJ07gDaAzoX/XAKS8PSaojml3M0DM4JpV1LAi5JOJ/p6H/XWrl8L+DzVEvVCW1z3vWAaB9oTsQw==}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
 
   astral-regex@2.0.0:
     resolution: {integrity: sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==}
@@ -1309,6 +1372,10 @@ packages:
 
   caniuse-lite@1.0.30001774:
     resolution: {integrity: sha512-DDdwPGz99nmIEv216hKSgLD+D4ikHQHjBC/seF98N9CPqRX4M5mSxT9eTV6oyisnJcuzxtZy4n17yKKQYmYQOA==}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
 
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
@@ -1596,6 +1663,9 @@ packages:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
 
+  es-module-lexer@2.1.0:
+    resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
+
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
     engines: {node: '>= 0.4'}
@@ -1678,6 +1748,9 @@ packages:
   estree-walker@2.0.2:
     resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
@@ -1692,6 +1765,10 @@ packages:
 
   evp_bytestokey@1.0.3:
     resolution: {integrity: sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   extract-zip@2.0.1:
     resolution: {integrity: sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==}
@@ -2156,24 +2233,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.30.2:
     resolution: {integrity: sha512-5Vh9dGeblpTxWHpOx8iauV02popZDsCYMPIgiuw97OJ5uaDsL86cnqSFs5LZkG3ghHoX5isLgWzMs+eD1YzrnA==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.30.2:
     resolution: {integrity: sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.30.2:
     resolution: {integrity: sha512-XJaLUUFXb6/QG2lGIW6aIk6jKdtjtcffUT0NKvIqhSBY3hh9Ch+1LCeH80dR9q9LBjG3ewbDjnumefsLsP6aiA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.30.2:
     resolution: {integrity: sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==}
@@ -2397,6 +2478,10 @@ packages:
     resolution: {integrity: sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==}
     engines: {node: '>= 0.4'}
 
+  obug@2.1.2:
+    resolution: {integrity: sha512-AWGB9WFcRXOQs48Z/udjI5ZcZMHXwX8XPByNpOydgcGsDLIzjGizhoMWJyKAWze7AVW/2W1i+/gPX4YtKe5cyg==}
+    engines: {node: '>=12.20.0'}
+
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
@@ -2458,6 +2543,9 @@ packages:
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
   pbkdf2@3.1.5:
     resolution: {integrity: sha512-Q3CG/cYvCO1ye4QKkuH7EXxs3VC/rI1/trd+qX2+PolbaKG0H+bgcZzrTt96mMyRtejk+JMCiLUn3y29W8qmFQ==}
@@ -2748,6 +2836,9 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
@@ -2782,9 +2873,15 @@ packages:
   sprintf-js@1.1.3:
     resolution: {integrity: sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
   stat-mode@1.0.0:
     resolution: {integrity: sha512-jH9EhtKIjuXZ2cWxmXS8ZP80XyC3iasQxMDV8jzhNJpfDb7VbQLVW4Wvsxz9QZvzV+G4YoSfBUVKDOyxLzi/sg==}
     engines: {node: '>= 6'}
+
+  std-env@4.1.0:
+    resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
   stream-browserify@3.0.0:
     resolution: {integrity: sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA==}
@@ -2874,9 +2971,20 @@ packages:
     resolution: {integrity: sha512-9phl76Cqm6FhSX9Xe1ZUAMLtm1BLkKj2Qd5ApyWkXzsMRaA7dgr81kf4wJmQf/hAvg8EEyJxDo3du/0KlhPiKQ==}
     engines: {node: '>=0.6.0'}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.2.4:
+    resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
+    engines: {node: '>=18'}
+
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
 
   tmp-promise@3.0.3:
     resolution: {integrity: sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ==}
@@ -3025,6 +3133,47 @@ packages:
       yaml:
         optional: true
 
+  vitest@4.1.8:
+    resolution: {integrity: sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.8
+      '@vitest/browser-preview': 4.1.8
+      '@vitest/browser-webdriverio': 4.1.8
+      '@vitest/coverage-istanbul': 4.1.8
+      '@vitest/coverage-v8': 4.1.8
+      '@vitest/ui': 4.1.8
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   vm-browserify@1.1.2:
     resolution: {integrity: sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==}
 
@@ -3038,6 +3187,11 @@ packages:
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   word-wrap@1.2.5:
@@ -3672,6 +3826,8 @@ snapshots:
 
   '@sindresorhus/is@4.6.0': {}
 
+  '@standard-schema/spec@1.1.0': {}
+
   '@szmarczak/http-timer@4.0.6':
     dependencies:
       defer-to-connect: 2.0.1
@@ -3774,9 +3930,16 @@ snapshots:
       '@types/node': 25.2.3
       '@types/responselike': 1.0.3
 
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
   '@types/debug@4.1.12':
     dependencies:
       '@types/ms': 2.1.0
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/estree@1.0.8': {}
 
@@ -3932,6 +4095,47 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@vitest/expect@4.1.8':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.8
+      '@vitest/utils': 4.1.8
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.8(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2))':
+    dependencies:
+      '@vitest/spy': 4.1.8
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)
+
+  '@vitest/pretty-format@4.1.8':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.8':
+    dependencies:
+      '@vitest/utils': 4.1.8
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.8':
+    dependencies:
+      '@vitest/pretty-format': 4.1.8
+      '@vitest/utils': 4.1.8
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.8': {}
+
+  '@vitest/utils@4.1.8':
+    dependencies:
+      '@vitest/pretty-format': 4.1.8
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
+
   '@xmldom/xmldom@0.8.11': {}
 
   acorn-jsx@5.3.2(acorn@8.16.0):
@@ -4072,6 +4276,8 @@ snapshots:
       object-is: 1.1.6
       object.assign: 4.1.7
       util: 0.12.5
+
+  assertion-error@2.0.1: {}
 
   astral-regex@2.0.0:
     optional: true
@@ -4281,6 +4487,8 @@ snapshots:
   callsites@3.1.0: {}
 
   caniuse-lite@1.0.30001774: {}
+
+  chai@6.2.2: {}
 
   chalk@4.1.2:
     dependencies:
@@ -4635,6 +4843,8 @@ snapshots:
 
   es-errors@1.3.0: {}
 
+  es-module-lexer@2.1.0: {}
+
   es-object-atoms@1.1.1:
     dependencies:
       es-errors: 1.3.0
@@ -4792,6 +5002,10 @@ snapshots:
 
   estree-walker@2.0.2: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
   esutils@2.0.3: {}
 
   ethers@6.16.0:
@@ -4813,6 +5027,8 @@ snapshots:
     dependencies:
       md5.js: 1.3.5
       safe-buffer: 5.2.1
+
+  expect-type@1.3.0: {}
 
   extract-zip@2.0.1:
     dependencies:
@@ -5517,6 +5733,8 @@ snapshots:
       has-symbols: 1.1.0
       object-keys: 1.1.1
 
+  obug@2.1.2: {}
+
   once@1.4.0:
     dependencies:
       wrappy: 1.0.2
@@ -5574,6 +5792,8 @@ snapshots:
       minipass: 7.1.3
 
   path-type@4.0.0: {}
+
+  pathe@2.0.3: {}
 
   pbkdf2@3.1.5:
     dependencies:
@@ -5896,6 +6116,8 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
   signal-exit@4.1.0: {}
 
   simple-update-notifier@2.0.0:
@@ -5926,7 +6148,11 @@ snapshots:
   sprintf-js@1.1.3:
     optional: true
 
+  stackback@0.0.2: {}
+
   stat-mode@1.0.0: {}
+
+  std-env@4.1.0: {}
 
   stream-browserify@3.0.0:
     dependencies:
@@ -6034,10 +6260,16 @@ snapshots:
     dependencies:
       setimmediate: 1.0.5
 
+  tinybench@2.9.0: {}
+
+  tinyexec@1.2.4: {}
+
   tinyglobby@0.2.15:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
+
+  tinyrainbow@3.1.0: {}
 
   tmp-promise@3.0.3:
     dependencies:
@@ -6156,6 +6388,33 @@ snapshots:
       jiti: 2.6.1
       lightningcss: 1.30.2
 
+  vitest@4.1.8(@types/node@25.2.3)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)):
+    dependencies:
+      '@vitest/expect': 4.1.8
+      '@vitest/mocker': 4.1.8(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2))
+      '@vitest/pretty-format': 4.1.8
+      '@vitest/runner': 4.1.8
+      '@vitest/snapshot': 4.1.8
+      '@vitest/spy': 4.1.8
+      '@vitest/utils': 4.1.8
+      es-module-lexer: 2.1.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.2
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.1.0
+      vite: 7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 25.2.3
+    transitivePeerDependencies:
+      - msw
+
   vm-browserify@1.1.2: {}
 
   when-exit@2.1.5: {}
@@ -6173,6 +6432,11 @@ snapshots:
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   word-wrap@1.2.5: {}
 

--- a/scripts/download-bins.js
+++ b/scripts/download-bins.js
@@ -41,6 +41,21 @@ const TARGETS = {
     }[remoteSubDir] || '0dbbab8147e3c6523c60ce5a62d35e3899606c727b7a2752c492f5fa8d07b3db',
     folder: 'rpc-core'
   },
+  // FCMP++/CARROT beta stressnet wallet-rpc (seraphis-migration build).
+  // OPTIONAL: missing artifacts must never fail a mainnet build -- the
+  // capability manifest simply hides stressnet mode on this platform.
+  // 'TBD' hash = binaries not yet published for that platform.
+  rpcStressnet: {
+    url: `https://raw.githubusercontent.com/KYC-rip/wallet-binaries/main/${remoteSubDir}/monero-rpc-stressnet.tar.gz`,
+    hash: {
+      'mac-arm64': 'TBD',
+      'mac-x64': 'TBD',
+      'linux-x64': 'TBD',
+      'win-x64': 'TBD'
+    }[remoteSubDir] || 'TBD',
+    folder: 'rpc-stressnet',
+    optional: true
+  },
 };
 
 const BIN_DIR = path.join(__dirname, '../resources/bin');
@@ -148,6 +163,20 @@ async function main() {
       downloadAndExtractTarGz('Tor Obfuscated Bundle', TARGETS.tor.url, TARGETS.tor.hash, TARGETS.tor.folder),
       downloadAndExtractTarGz('Monero Lone Wolf Engine', TARGETS.rpc.url, TARGETS.rpc.hash, TARGETS.rpc.folder)
     ]);
+
+    // Optional stressnet engine: tolerate-missing, record capability
+    let stressnet = false;
+    if (TARGETS.rpcStressnet.hash !== 'TBD') {
+      try {
+        await downloadAndExtractTarGz('FCMP++ Stressnet Engine', TARGETS.rpcStressnet.url, TARGETS.rpcStressnet.hash, TARGETS.rpcStressnet.folder);
+        stressnet = true;
+      } catch (err) {
+        console.warn(`  [OPTIONAL] Stressnet engine unavailable for ${remoteSubDir} (${err.message}). Feature will be hidden.`);
+      }
+    } else {
+      console.warn(`  [OPTIONAL] Stressnet binaries not yet published for ${remoteSubDir}. Feature will be hidden.`);
+    }
+    fs.writeFileSync(path.join(BIN_DIR, 'capabilities.json'), JSON.stringify({ stressnet }), 'utf8');
 
     console.log(`\n=== 🟢 Armory assembled. Ready for React rendering layer! ===\n`);
   } catch (err) {

--- a/src/main/DaemonManager.ts
+++ b/src/main/DaemonManager.ts
@@ -3,6 +3,7 @@ import { spawn, ChildProcess } from 'child_process';
 import fs from 'fs';
 import path from 'path';
 import { app } from 'electron';
+import { getWalletDirName, getRpcFolderName, getNetworkFlag } from './networkPaths';
 
 export class DaemonManager {
   private binPath: string;
@@ -36,6 +37,27 @@ export class DaemonManager {
     this.rpcPath = path.join(this.binPath, `rpc-core/monero-wallet-rpc${ext}`);
 
     this.walletDir = path.join(app.getPath('userData'), 'wallets');
+    if (!fs.existsSync(this.walletDir)) fs.mkdirSync(this.walletDir, { recursive: true });
+  }
+
+  /**
+   * Resolve the wallet dir and rpc binary for the requested network.
+   * Called at startMoneroRpc time (engine reloads fully on network change),
+   * so there are no stale references. Throws when the stressnet binary is
+   * not bundled for this platform (capability manifest also hides the
+   * option in the UI; this is the backstop).
+   */
+  private applyNetworkPaths(network: string) {
+    const ext = process.platform === 'win32' ? '.exe' : '';
+    this.rpcPath = path.join(this.binPath, `${getRpcFolderName(network)}/monero-wallet-rpc${ext}`);
+    this.walletDir = path.join(app.getPath('userData'), getWalletDirName(network));
+
+    if (!fs.existsSync(this.rpcPath)) {
+      if (network === 'stressnet') {
+        throw new Error('Stressnet build unavailable on this platform (missing rpc-stressnet binary)');
+      }
+      throw new Error(`monero-wallet-rpc binary missing at ${this.rpcPath}`);
+    }
     if (!fs.existsSync(this.walletDir)) fs.mkdirSync(this.walletDir, { recursive: true });
   }
 
@@ -148,6 +170,8 @@ export class DaemonManager {
     systemProxyAddress: string,
     network: string
   ): Promise<void> {
+    this.applyNetworkPaths(network);
+
     if (process.platform !== 'win32') {
       try {
         fs.chmodSync(this.rpcPath, 0o755);
@@ -169,11 +193,8 @@ export class DaemonManager {
         '--no-initial-sync'
       ];
 
-      if (network === 'stagenet') {
-        rpcArgs.push('--stagenet');
-      } else if (network === 'testnet') {
-        rpcArgs.push('--testnet');
-      }
+      const networkFlag = getNetworkFlag(network);
+      if (networkFlag) rpcArgs.push(networkFlag);
 
       const env = Object.assign({}, process.env);
       if (useTor) {

--- a/src/main/__tests__/networkPaths.test.ts
+++ b/src/main/__tests__/networkPaths.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { getWalletDirName, getRpcFolderName, getNetworkFlag, getNetworkLabel, parseCapabilities } from '../networkPaths';
+
+describe('getWalletDirName', () => {
+  it('hard-separates stressnet wallets; mainnet/stagenet keep the legacy dir', () => {
+    expect(getWalletDirName('mainnet')).toBe('wallets');
+    expect(getWalletDirName('stagenet')).toBe('wallets');
+    expect(getWalletDirName('stressnet')).toBe('wallets-stressnet');
+  });
+});
+
+describe('getRpcFolderName', () => {
+  it('selects the stressnet binary only for stressnet', () => {
+    expect(getRpcFolderName('mainnet')).toBe('rpc-core');
+    expect(getRpcFolderName('stagenet')).toBe('rpc-core');
+    expect(getRpcFolderName('stressnet')).toBe('rpc-stressnet');
+  });
+});
+
+describe('getNetworkFlag', () => {
+  it('maps networks to wallet-rpc CLI flags (stressnet is a testnet fork)', () => {
+    expect(getNetworkFlag('mainnet')).toBeNull();
+    expect(getNetworkFlag('stagenet')).toBe('--stagenet');
+    expect(getNetworkFlag('testnet')).toBe('--testnet');
+    expect(getNetworkFlag('stressnet')).toBe('--testnet');
+  });
+});
+
+describe('getNetworkLabel', () => {
+  it('drives the header chip', () => {
+    expect(getNetworkLabel('mainnet')).toBe('');
+    expect(getNetworkLabel('stagenet')).toBe('STAGENET');
+    expect(getNetworkLabel('stressnet')).toBe('FCMP++ STRESSNET');
+  });
+});
+
+describe('parseCapabilities', () => {
+  it('fails safe: missing/corrupt manifests hide stressnet', () => {
+    expect(parseCapabilities(null)).toEqual({ stressnet: false });
+    expect(parseCapabilities(undefined)).toEqual({ stressnet: false });
+    expect(parseCapabilities('not json{')).toEqual({ stressnet: false });
+    expect(parseCapabilities('{}')).toEqual({ stressnet: false });
+    expect(parseCapabilities('{"stressnet":"yes"}')).toEqual({ stressnet: false });
+  });
+
+  it('enables stressnet only on an explicit true', () => {
+    expect(parseCapabilities('{"stressnet":true}')).toEqual({ stressnet: true });
+  });
+});

--- a/src/main/handlers/IdentityHandler.ts
+++ b/src/main/handlers/IdentityHandler.ts
@@ -4,22 +4,25 @@ import fs from 'fs/promises'; // 🚀 Force async API to prevent UI stutter
 import { existsSync } from 'fs';
 import path from 'path';
 import { WalletManager } from '../WalletManager';
+import { getWalletDirName } from '../networkPaths';
 
 export function registerIdentityHandlers(store: any) {
-  const walletDir = path.join(app.getPath('userData'), 'wallets');
+  // Resolved per call: identities are network-scoped (stressnet wallets live
+  // in their own dir) and the network can change at runtime via engine reload.
+  const walletDir = () => path.join(app.getPath('userData'), getWalletDirName(store.get('network') || 'mainnet'));
 
   // 🔍 Fetch list: Force reconciliation between physical disk and Store database
   ipcMain.handle('get-identities', async () => {
     try {
-      if (!existsSync(walletDir)) {
-        await fs.mkdir(walletDir, { recursive: true });
+      if (!existsSync(walletDir())) {
+        await fs.mkdir(walletDir(), { recursive: true });
       }
 
       // 1. Read the absolute truth: physical vault files on disk
-      const files = await fs.readdir(walletDir);
+      const files = await fs.readdir(walletDir());
       const keyFiles = files.filter(f => f.endsWith('.keys'));
 
-      console.log(`${keyFiles.length} key files found in ${walletDir}`)
+      console.log(`${keyFiles.length} key files found in ${walletDir()}`)
 
       // 2. Read auxiliary attributes: alias records in the Store
       const storedIds: any[] = store.get('identities') || [];
@@ -34,7 +37,7 @@ export function registerIdentityHandlers(store: any) {
           return existingMeta;
         } else {
           // 👻 "Ghost Wallet" detected: physical file present but no record in Store
-          const stats = await fs.stat(path.join(walletDir, fileName));
+          const stats = await fs.stat(path.join(walletDir(), fileName));
           return {
             id: id,
             name: id, // Default to filename as display name
@@ -86,8 +89,8 @@ export function registerIdentityHandlers(store: any) {
       // holds a file lock on .keys files, preventing deletion
       await WalletManager.closeWallet().catch(() => { });
 
-      const keysFile = path.join(walletDir, `${id}.keys`);
-      const cacheFile = path.join(walletDir, id); // wallet cache file (no extension)
+      const keysFile = path.join(walletDir(), `${id}.keys`);
+      const cacheFile = path.join(walletDir(), id); // wallet cache file (no extension)
 
       if (existsSync(keysFile)) await fs.unlink(keysFile);
       if (existsSync(cacheFile)) await fs.unlink(cacheFile);

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -8,6 +8,7 @@ import { WalletManager } from './WalletManager';
 import { SyncWatcher } from './SyncWatcher';
 import { AppConfig } from './types';
 import { registerIdentityHandlers } from './handlers/IdentityHandler';
+import { getNetworkLabel, getWalletDirName, parseCapabilities } from './networkPaths';
 import { AgentGateway } from './AgentGateway';
 
 if (process.defaultApp) {
@@ -121,7 +122,20 @@ if (!gotTheLock) {
 
 // 🟢 Global State Tracker (For UI polling)
 const isStagenet = store.get("network") === 'stagenet';
-let currentEngineState = { status: 'DISCONNECTED', node: '', nodeLabel: '', useTor: false, error: '', isStagenet };
+let currentEngineState = { status: 'DISCONNECTED', node: '', nodeLabel: '', useTor: false, error: '', isStagenet, networkLabel: getNetworkLabel(store.get("network") || 'mainnet') };
+
+function readBinCapabilities() {
+  try {
+    const binDir = app.isPackaged
+      ? join(process.resourcesPath, 'bin')
+      : join(__dirname, '../../resources/bin');
+    const raw = require('fs').readFileSync(join(binDir, 'capabilities.json'), 'utf8');
+    return parseCapabilities(raw);
+  } catch {
+    // Missing or unreadable manifest fails safe: stressnet hidden
+    return parseCapabilities(null);
+  }
+}
 let isSafeToExit = false;
 
 function emitAppLog(source: string, level: 'info' | 'error', message: string) {
@@ -240,7 +254,12 @@ app.whenReady().then(async () => {
   // 🔌 Register the Identity/Vault Handlers
   registerIdentityHandlers(store);
 
-  agentGateway = new AgentGateway(mainWindow, store);
+  // Agents never touch stressnet test wallets — gateway stays down there.
+  if (store.get('network') !== 'stressnet') {
+    agentGateway = new AgentGateway(mainWindow, store);
+  } else {
+    console.log('[AgentGateway] Disabled on stressnet.');
+  }
   if (store.get('agent_config.enabled')) {
     agentGateway.start();
   }
@@ -326,9 +345,10 @@ app.whenReady().then(async () => {
     return {
       version: app.getVersion(),
       appDataPath: app.getPath('appData'),
-      walletsPath: join(app.getPath('userData'), 'wallets'),
+      walletsPath: join(app.getPath('userData'), getWalletDirName(store.get('network') || 'mainnet')),
       platform: process.platform,
-      isPackaged: app.isPackaged
+      isPackaged: app.isPackaged,
+      capabilities: readBinCapabilities()
     };
   });
 
@@ -809,12 +829,12 @@ async function reloadEngine(forceRestart = false) {
       customNodeAddress: config.customNodeAddress
     };
 
-    currentEngineState = { status: 'ONLINE', node: targetNode, nodeLabel: NodeManager.activeNodeLabel, useTor, error: '', isStagenet: config.network === 'stagenet' };
+    currentEngineState = { status: 'ONLINE', node: targetNode, nodeLabel: NodeManager.activeNodeLabel, useTor, error: '', isStagenet: config.network === 'stagenet', networkLabel: getNetworkLabel(config.network) };
     mainWindow?.webContents.send('engine-status', currentEngineState);
 
   } catch (error: any) {
     console.error('[Engine] Start failed:', error);
-    currentEngineState = { status: 'ERROR', node: '', nodeLabel: '', useTor: false, error: error.message, isStagenet: config.network === 'stagenet' };
+    currentEngineState = { status: 'ERROR', node: '', nodeLabel: '', useTor: false, error: error.message, isStagenet: config.network === 'stagenet', networkLabel: getNetworkLabel(config.network) };
     mainWindow?.webContents.send('engine-status', currentEngineState);
   }
 }

--- a/src/main/networkPaths.ts
+++ b/src/main/networkPaths.ts
@@ -1,0 +1,51 @@
+/**
+ * Pure network->path/flag resolution (no Electron imports so vitest can
+ * exercise the matrix). 'stressnet' is the FCMP++/CARROT beta stressnet —
+ * a fork of the Monero testnet running seraphis-migration builds, so it
+ * uses the --testnet daemon flag with a dedicated binary and wallet dir.
+ *
+ * Mainnet and stagenet intentionally keep sharing the legacy 'wallets' dir
+ * (pre-existing behavior; a wallet can only be open on one network at a
+ * time). Stressnet gets a hard-separated dir so experimental chain state
+ * can never touch real wallets.
+ */
+
+export type MoneroNetwork = 'mainnet' | 'stagenet' | 'stressnet';
+
+export function getWalletDirName(network: string): string {
+  return network === 'stressnet' ? 'wallets-stressnet' : 'wallets';
+}
+
+/** Folder under resources/bin that holds monero-wallet-rpc for this network. */
+export function getRpcFolderName(network: string): string {
+  return network === 'stressnet' ? 'rpc-stressnet' : 'rpc-core';
+}
+
+/** CLI network flag for monero-wallet-rpc (null = mainnet, no flag). */
+export function getNetworkFlag(network: string): string | null {
+  if (network === 'stagenet') return '--stagenet';
+  if (network === 'testnet' || network === 'stressnet') return '--testnet';
+  return null;
+}
+
+/** Header badge text shown in the renderer. Empty string = no badge. */
+export function getNetworkLabel(network: string): string {
+  if (network === 'stagenet') return 'STAGENET';
+  if (network === 'stressnet') return 'FCMP++ STRESSNET';
+  return '';
+}
+
+export interface BinCapabilities {
+  stressnet: boolean;
+}
+
+/** Missing or corrupt manifest must fail SAFE: hide stressnet. */
+export function parseCapabilities(raw: string | null | undefined): BinCapabilities {
+  if (!raw) return { stressnet: false };
+  try {
+    const data = JSON.parse(raw);
+    return { stressnet: data?.stressnet === true };
+  } catch {
+    return { stressnet: false };
+  }
+}

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -12,6 +12,7 @@ import { AddressDisplay } from './components/common/AddressDisplay';
 import { AgentTab } from './components/vault/AgentTab';
 import { ExchangeView } from './components/ExchangeView';
 import { VigilView } from './components/VigilView';
+import { setNetworkLabel, isStressnet } from './utils/networkMode';
 import { XMR402Modal } from './components/common/XMR402Modal';
 import { VaultProvider } from './contexts/VaultContext';
 
@@ -60,6 +61,7 @@ function MainApp() {
   const [showScanlines, setShowScanlines] = useState(resolvedTheme === 'dark');
   const [autoLockMinutes, setAutoLockMinutes] = useState(0);
   const [uplink, setUplink] = useState<string>('SCANNING...');
+  const [netLabel, setNetLabel] = useState<string>('');
   const [uplinkUrl, setUplinkUrl] = useState<string>('');
   const [sessionStartTime] = useState(Date.now());
   const [uptime, setUptime] = useState('00:00:00');
@@ -206,6 +208,8 @@ function MainApp() {
       try {
         const s = await window.api.getUplinkStatus();
         if (s) {
+          setNetworkLabel(s.networkLabel || '');
+          setNetLabel(s.networkLabel || '');
           if (s.nodeLabel) {
             setUplink(s.nodeLabel);
             setUplinkUrl(s.node);
@@ -389,10 +393,12 @@ function MainApp() {
           <NavButton id="home" label="Dashboard" icon={Ghost} />
           <NavButton id="vault" label="Vault" icon={Shield} badge={isSyncing ? `${syncPercent.toFixed(1)}%` : null} />
 
-          <NavGroup label="Exchange" groupKey="exchange">
-            <NavButton id="exchange" label="Exchange" icon={ArrowDown} />
-            {!isPackaged && <NavButton id="vigil" label="Vigil / Limit" icon={Crosshair} />}
-          </NavGroup>
+          {!isStressnet() && (
+            <NavGroup label="Exchange" groupKey="exchange">
+              <NavButton id="exchange" label="Exchange" icon={ArrowDown} />
+              {!isPackaged && <NavButton id="vigil" label="Vigil / Limit" icon={Crosshair} />}
+            </NavGroup>
+          )}
 
           <NavGroup label="Tools" groupKey="tools">
             <NavButton id="agent" label="Agent" icon={Bot} />
@@ -449,6 +455,11 @@ function MainApp() {
       <div className="flex-grow flex flex-col min-w-0 bg-transparent relative z-10">
         <header className="h-14 flex items-center justify-end px-8 border-b border-xmr-border/20 bg-xmr-surface/80 backdrop-blur-md shrink-0" style={{ WebkitAppRegion: 'drag' } as any}>
           <div className="flex gap-6 text-[10px] font-black uppercase tracking-[0.2em]" style={{ WebkitAppRegion: 'no-drag' } as any}>
+            {netLabel && (
+              <span className="flex items-center px-2 py-0.5 rounded-sm border border-xmr-warning/50 bg-xmr-warning/10 text-xmr-warning">
+                {netLabel}
+              </span>
+            )}
             <span className="flex items-center gap-2 text-xmr-dim">SESSION: <span className="text-xmr-green opacity-80 font-black">{uptime}</span></span>
             <span className="flex items-center gap-2 text-xmr-dim">XMR: <span className="text-xmr-accent font-black">${stats?.price.street || '---.--'}</span></span>
             <span className="flex items-center gap-2 text-xmr-dim">POOL: <span className={(stats?.network.mempool || 0) > 50 ? "text-orange-500" : "text-xmr-green"}>{stats?.network.mempool ?? '--'} TXs</span></span>
@@ -506,8 +517,8 @@ function MainApp() {
 
               <div className={view === 'home' ? 'block' : 'hidden'}><HomeView setView={setView} stats={stats} loading={statsLoading} /></div>
                 <div className={view === 'vault' ? 'block' : 'hidden'}><VaultView setView={setView} vault={vault} handleBurn={() => purgeIdentity(activeId)} appConfig={appConfig} /></div>
-                <div className={view === 'exchange' ? 'block' : 'hidden'}><ExchangeView localXmrAddress={address} /></div>
-                {!isPackaged && <div className={view === 'vigil' ? 'block' : 'hidden'}><VigilView localXmrAddress={address} /></div>}
+                {!isStressnet() && <div className={view === 'exchange' ? 'block' : 'hidden'}><ExchangeView localXmrAddress={address} /></div>}
+                {!isPackaged && !isStressnet() && <div className={view === 'vigil' ? 'block' : 'hidden'}><VigilView localXmrAddress={address} /></div>}
 
               <div className={view === 'settings' ? 'block' : 'hidden'}><SettingsView /></div>
                 <div className={view === 'agent' ? 'block' : 'hidden'}><AgentTab /></div>

--- a/src/renderer/components/SettingsView.tsx
+++ b/src/renderer/components/SettingsView.tsx
@@ -32,7 +32,7 @@ export function SettingsView() {
   const [isRescanning, setIsRescanning] = useState(false);
 
   // 📦 App Info & Updates state
-  const [appInfo, setAppInfo] = useState<{ version: string; appDataPath: string; walletsPath: string; platform: string } | null>(null);
+  const [appInfo, setAppInfo] = useState<{ version: string; appDataPath: string; walletsPath: string; platform: string; capabilities?: { stressnet: boolean } } | null>(null);
   const [isCheckingUpdate, setIsCheckingUpdate] = useState(false);
   const [updateResult, setUpdateResult] = useState<{
     checked: boolean;
@@ -301,21 +301,38 @@ export function SettingsView() {
               </button>
             </div>
 
-            {/* Network Toggle (Mainnet vs Stagenet) */}
-            <div className={`flex items-center justify-between p-4 border rounded-sm transition-all ${localSettings.network === 'stagenet' ? 'bg-xmr-accent/10 border-xmr-accent/40' : 'bg-xmr-green/5 border-xmr-border opacity-60'}`}>
+            {/* Network Selector (Mainnet / Stagenet / FCMP++ Stressnet) */}
+            <div className={`p-4 border rounded-sm transition-all space-y-3 ${localSettings.network !== 'mainnet' ? 'bg-xmr-accent/10 border-xmr-accent/40' : 'bg-xmr-green/5 border-xmr-border'}`}>
               <div className="space-y-1">
                 <div className="flex items-center gap-2">
-                  <RefreshCw size={14} className={localSettings.network === 'stagenet' ? "text-xmr-accent animate-spin" : "text-xmr-dim"} />
-                  <span className={`text-xs font-black uppercase ${localSettings.network === 'stagenet' ? 'text-xmr-accent' : ''}`}>Stagenet_Protocol</span>
+                  <RefreshCw size={14} className={localSettings.network !== 'mainnet' ? "text-xmr-accent animate-spin" : "text-xmr-dim"} />
+                  <span className={`text-xs font-black uppercase ${localSettings.network !== 'mainnet' ? 'text-xmr-accent' : ''}`}>Network_Protocol</span>
                 </div>
-                <p className="text-xs text-xmr-dim uppercase font-black">Sandbox_Test_Network</p>
+                <p className="text-xs text-xmr-dim uppercase font-black">Wallets are stored per-network and never mix</p>
               </div>
-              <button
-                onClick={() => setLocalSettings({ ...localSettings, network: localSettings.network === 'stagenet' ? 'mainnet' : 'stagenet' })}
-                className={`w-10 h-5 rounded-full relative transition-all cursor-pointer ${localSettings.network === 'stagenet' ? 'bg-xmr-accent' : 'bg-xmr-base border border-xmr-border'}`}
-              >
-                <div className={`absolute top-0.5 w-3 h-3 rounded-full transition-all ${localSettings.network === 'stagenet' ? 'right-1 bg-xmr-base' : 'left-1 bg-xmr-border'}`}></div>
-              </button>
+              <div className="grid grid-cols-3 gap-2">
+                {([
+                  { id: 'mainnet', label: 'MAINNET' },
+                  { id: 'stagenet', label: 'STAGENET' },
+                  ...(appInfo?.capabilities?.stressnet ? [{ id: 'stressnet', label: 'STRESSNET FCMP++' }] : []),
+                ] as { id: string; label: string }[]).map((net) => (
+                  <button
+                    key={net.id}
+                    onClick={() => setLocalSettings({ ...localSettings, network: net.id })}
+                    className={`px-2 py-2 border rounded-sm text-[10px] font-black uppercase tracking-wider transition-all cursor-pointer
+                      ${localSettings.network === net.id
+                        ? net.id === 'stressnet' ? 'bg-xmr-warning/10 border-xmr-warning text-xmr-warning' : 'bg-xmr-accent/10 border-xmr-accent text-xmr-accent'
+                        : 'bg-xmr-base border-xmr-border text-xmr-dim hover:border-xmr-dim/50'}`}
+                  >
+                    {net.label}
+                  </button>
+                ))}
+              </div>
+              {localSettings.network === 'stressnet' && (
+                <p className="text-[10px] text-xmr-warning uppercase font-black">
+                  FCMP++/CARROT beta stressnet — test coins only, chain may reset
+                </p>
+              )}
             </div>
 
             {/* System Proxy */}

--- a/src/renderer/components/VaultView.tsx
+++ b/src/renderer/components/VaultView.tsx
@@ -10,6 +10,8 @@ import { ReceiveModal } from './vault/ReceiveModal';
 import { type VaultContextType } from '../contexts/VaultContext';
 import { WalletService } from '../services/walletService';
 import { useFiatValue } from '../hooks/useFiatValue';
+import { FaucetCard } from './vault/FaucetCard';
+import { isStressnet } from '../utils/networkMode';
 
 interface VaultViewProps {
   setView: (v: any) => void;
@@ -171,6 +173,9 @@ export function VaultView({ setView, vault, handleBurn, appConfig }: VaultViewPr
 
   return (
     <div className="max-w-6xl mx-auto space-y-6 py-2 pt-0 animate-in fade-in zoom-in-95 duration-300 font-black relative">
+
+      {/* STRESSNET FAUCET — empty test wallets get one obvious action */}
+      {isStressnet() && totalBalance <= 0 && <FaucetCard address={address} />}
 
       {/* SYNC STATUS BANNER — only for heavy syncs (>1000 blocks behind) */}
       {isHeavySync && (

--- a/src/renderer/components/vault/DispatchModal.tsx
+++ b/src/renderer/components/vault/DispatchModal.tsx
@@ -4,6 +4,7 @@ import { useVault } from '../../contexts/VaultContext';
 import { DispatchPasswordGate } from './DispatchPasswordGate';
 import { DirectSendTab } from './DirectSendTab';
 import { GhostSendTab } from './GhostSendTab';
+import { isStressnet } from '../../utils/networkMode';
 
 interface DispatchModalProps {
   onClose: () => void;
@@ -71,7 +72,8 @@ export function DispatchModal({ onClose, initialAddress = '', sourceSubaddressIn
             {/* Sub-tabs: Direct / Ghost */}
             {[
               { id: 'direct' as const, label: 'Direct XMR', icon: <Send size={12} /> },
-              { id: 'ghost' as const, label: 'Ghost Send', icon: <Ghost size={12} /> },
+              // Ghost Send needs the swap API, which has no stressnet support
+              ...(isStressnet() ? [] : [{ id: 'ghost' as const, label: 'Ghost Send', icon: <Ghost size={12} /> }]),
             ].map((t) => (
               <button
                 key={t.id}

--- a/src/renderer/components/vault/FaucetCard.tsx
+++ b/src/renderer/components/vault/FaucetCard.tsx
@@ -1,0 +1,79 @@
+import { useState } from 'react';
+import { Droplets, Loader2, Check } from 'lucide-react';
+import { getApiBase } from '../../services/client';
+
+/**
+ * Stressnet-only: claim 0.5 tXMR from the kyc.rip faucet so users can try
+ * the FCMP++ wallet flow without mining. Shown when the balance is zero.
+ */
+const ERROR_COPY: Record<string, string> = {
+  RATE_LIMITED: 'RATE_LIMITED — this address or IP already claimed',
+  EXHAUSTED: 'EXHAUSTED — faucet is empty, ping the operator',
+  INVALID_ADDRESS: 'INVALID_ADDRESS — stressnet address rejected',
+  DISABLED: 'DISABLED — faucet is switched off',
+  UPSTREAM_DOWN: 'UPSTREAM_DOWN — faucet node unreachable, retry later',
+};
+
+export function FaucetCard({ address }: { address: string }) {
+  const [busy, setBusy] = useState(false);
+  const [txid, setTxid] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const claim = async () => {
+    if (busy || !address) return;
+    setBusy(true);
+    setError(null);
+    try {
+      const base = getApiBase().replace(/\/$/, '');
+      const res = await fetch(`${base}/v1/faucet/stressnet/claim`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ address }),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (res.ok && data.txid) {
+        setTxid(data.txid);
+      } else {
+        setError(ERROR_COPY[data.error] || data.error || `HTTP_${res.status}`);
+      }
+    } catch (e: any) {
+      setError(`NETWORK_ERROR — ${e.message}`);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  if (txid) {
+    return (
+      <div className="border border-xmr-green/40 bg-xmr-green/5 rounded-sm p-3 flex items-center gap-3 animate-in fade-in">
+        <Check size={16} className="text-xmr-green shrink-0" />
+        <div className="min-w-0">
+          <div className="text-[10px] font-black uppercase text-xmr-green">0.5 tXMR dispatched — it will appear after confirmation</div>
+          <div className="text-[9px] font-mono text-xmr-dim truncate">TX: {txid}</div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="border border-xmr-warning/40 bg-xmr-warning/5 rounded-sm p-3 space-y-2 animate-in fade-in">
+      <div className="flex items-center justify-between gap-3">
+        <div className="flex items-center gap-2 min-w-0">
+          <Droplets size={16} className="text-xmr-warning shrink-0" />
+          <div className="text-[10px] font-black uppercase text-xmr-warning">
+            Empty stressnet wallet — grab test coins from the faucet
+          </div>
+        </div>
+        <button
+          onClick={claim}
+          disabled={busy || !address}
+          className="px-4 py-1.5 border border-xmr-warning/60 text-xmr-warning rounded-sm text-[10px] font-black uppercase tracking-widest hover:bg-xmr-warning/10 disabled:opacity-40 disabled:cursor-not-allowed transition-all flex items-center gap-2 shrink-0"
+        >
+          {busy ? <Loader2 size={12} className="animate-spin" /> : <Droplets size={12} />}
+          CLAIM 0.5 tXMR
+        </button>
+      </div>
+      {error && <div className="text-[10px] font-mono uppercase text-xmr-error">{error}</div>}
+    </div>
+  );
+}

--- a/src/renderer/components/vault/FaucetCard.tsx
+++ b/src/renderer/components/vault/FaucetCard.tsx
@@ -25,10 +25,12 @@ export function FaucetCard({ address }: { address: string }) {
     setError(null);
     try {
       const base = getApiBase().replace(/\/$/, '');
+      // 15s ceiling so a hung Worker never leaves an infinite spinner
       const res = await fetch(`${base}/v1/faucet/stressnet/claim`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ address }),
+        signal: AbortSignal.timeout(15_000),
       });
       const data = await res.json().catch(() => ({}));
       if (res.ok && data.txid) {

--- a/src/renderer/hooks/useFiatValue.ts
+++ b/src/renderer/hooks/useFiatValue.ts
@@ -1,5 +1,6 @@
 // ui/src/hooks/useFiatValue.ts
 import { useState, useEffect } from 'react';
+import { isStressnet } from '../utils/networkMode';
 
 // struct: { "BTC": { price: 98000, timestamp: 1712345678900 } }
 const priceCache: Record<string, { price: number; timestamp: number }> = {};
@@ -26,6 +27,12 @@ export function useFiatValue(ticker?: string, amount?: string | number, withPref
   };
 
   useEffect(() => {
+    // Stressnet coins have no fiat price — suppress all fiat display
+    if (isStressnet()) {
+        setFiatText(null);
+        setPremium(null);
+        return;
+    }
     if (!ticker || amount === undefined || amount === null || amount === '') {
         setFiatText(null);
         setPremium(null);

--- a/src/renderer/utils/networkMode.ts
+++ b/src/renderer/utils/networkMode.ts
@@ -11,7 +11,7 @@ export function setNetworkLabel(label: string) {
   currentLabel = label || '';
 }
 
-export function getNetworkLabel(): string {
+export function getActiveNetworkLabel(): string {
   return currentLabel;
 }
 

--- a/src/renderer/utils/networkMode.ts
+++ b/src/renderer/utils/networkMode.ts
@@ -1,0 +1,20 @@
+/**
+ * Process-wide network mode mirror for the renderer. App.tsx sets this from
+ * engine status; leaf consumers (fiat hook, dispatch tabs, faucet card) read
+ * it without threading props through every layer. The value only changes
+ * with a full engine reload, so render-time staleness is not a concern.
+ */
+
+let currentLabel = '';
+
+export function setNetworkLabel(label: string) {
+  currentLabel = label || '';
+}
+
+export function getNetworkLabel(): string {
+  return currentLabel;
+}
+
+export function isStressnet(): boolean {
+  return currentLabel.includes('STRESSNET');
+}

--- a/src/renderer/window.d.ts
+++ b/src/renderer/window.d.ts
@@ -35,6 +35,8 @@ export interface EngineStatus {
   useTor: boolean;
   error?: string;
   isStagenet: boolean;
+  /** '' | 'STAGENET' | 'FCMP++ STRESSNET' — drives the header chip */
+  networkLabel?: string;
 }
 
 export interface VaultIdentity {
@@ -90,7 +92,7 @@ export interface IApi {
   proxyRequest: (payload: { method: string; params: any }) => Promise<{ success: boolean; result?: any; error?: string }>;
 
   // --- App Info & Updates ---
-  getAppInfo: () => Promise<{ version: string; appDataPath: string; walletsPath: string; platform: NodeJS.Platform; isPackaged: boolean }>;
+  getAppInfo: () => Promise<{ version: string; appDataPath: string; walletsPath: string; platform: NodeJS.Platform; isPackaged: boolean; capabilities?: { stressnet: boolean } }>;
   openPath: (targetPath: string) => Promise<{ success: boolean; error?: string }>;
   openExternal: (url: string) => Promise<{ success: boolean; error?: string }>;
   checkForUpdates: (include_prereleases: boolean) => Promise<{ success: boolean; hasUpdate?: boolean; latestVersion?: string; releaseUrl?: string; body?: string; publishedAt?: string; error?: string }>;


### PR DESCRIPTION
Implements the opencode-approved plan (7.6/10): FCMP++/CARROT beta stressnet as a third network with hard wallet isolation, capability-gated binaries, and a faucet.

- `networkPaths.ts`: pure network→walletDir/binary/flag/label resolution (6 unit tests)
- Stressnet wallets live in `wallets-stressnet` — can never mix with mainnet
- `download-bins.js`: optional `rpc-stressnet` target (hashes TBD until binaries are repackaged from [seraphis-migration releases](https://github.com/seraphis-migration/monero/releases) into wallet-binaries — **upload before merge**), writes `capabilities.json` that fails safe (missing/corrupt → stressnet hidden)
- UX map per plan: Exchange/Ghost/Vigil hidden, fiat suppressed, AgentGateway not started, FCMP++ STRESSNET header chip, 3-way network selector (stressnet option capability-gated)
- `FaucetCard`: CLAIM 0.5 tXMR on empty stressnet wallets → `POST /v1/faucet/stressnet/claim` (API in kyc-rip repo, branch `feat/stressnet-faucet`)
- `docs/fcmp-stressnet-vps.md`: VPS monerod + faucet wallet-rpc + cloudflared setup

Pending before merge: repackage + upload stressnet binaries w/ hashes; deploy faucet API (preview); VPS provisioning; smoke per plan step 13 (incl. FCMP++ tx-type verification via get_transfers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)