### PR TITLE
refactor: UI consistency, dead code, type safety, and perf fixes

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -55,7 +55,7 @@ const store = new Store({
     include_prereleases: false,
     agent_config: {
       enabled: false,
-      apiKey: 'RG-' + Math.random().toString(36).substring(2, 15).toUpperCase(),
+      apiKey: 'RG-' + crypto.randomUUID().replace(/-/g, '').substring(0, 13).toUpperCase(),
       dailyLimit: '0.1',
       totalLimit: '1.0',
       port: 38084,
@@ -250,28 +250,31 @@ app.whenReady().then(async () => {
   ipcMain.handle('get-uplink-status', () => currentEngineState);
   ipcMain.handle('retry-engine', () => reloadEngine(true));
 
+  const skinBgPath = join(app.getPath('userData'), 'skin_bg.b64');
+
+  const persistSkinBackground = (configToSave: any) => {
+    if (!('skin_background' in configToSave)) return;
+    const fs = require('fs');
+    if (configToSave.skin_background) {
+      fs.writeFileSync(skinBgPath, configToSave.skin_background, 'utf8');
+    } else if (fs.existsSync(skinBgPath)) {
+      fs.unlinkSync(skinBgPath);
+    }
+    delete configToSave.skin_background;
+  };
+
   ipcMain.handle('get-config', () => {
     const config = { ...store.store } as any;
     const fs = require('fs');
-    const skinPath = join(app.getPath('userData'), 'skin_bg.b64');
-    if (fs.existsSync(skinPath)) {
-      try { config.skin_background = fs.readFileSync(skinPath, 'utf8'); } catch (e) { }
+    if (fs.existsSync(skinBgPath)) {
+      try { config.skin_background = fs.readFileSync(skinBgPath, 'utf8'); } catch (e) { }
     }
     return config;
   });
 
   ipcMain.handle('save-config-and-reload', async (_, newConfig: AppConfig) => {
     const configToSave = { ...newConfig } as any;
-    if ('skin_background' in configToSave) {
-      const fs = require('fs');
-      const skinPath = join(app.getPath('userData'), 'skin_bg.b64');
-      if (configToSave.skin_background) {
-        fs.writeFileSync(skinPath, configToSave.skin_background, 'utf8');
-      } else if (fs.existsSync(skinPath)) {
-        fs.unlinkSync(skinPath);
-      }
-      delete configToSave.skin_background;
-    }
+    persistSkinBackground(configToSave);
     store.set(configToSave);
     try {
       await reloadEngine();
@@ -283,16 +286,7 @@ app.whenReady().then(async () => {
 
   ipcMain.handle('save-config-only', (_, newConfig: AppConfig) => {
     const configToSave = { ...newConfig } as any;
-    if ('skin_background' in configToSave) {
-      const fs = require('fs');
-      const skinPath = join(app.getPath('userData'), 'skin_bg.b64');
-      if (configToSave.skin_background) {
-        fs.writeFileSync(skinPath, configToSave.skin_background, 'utf8');
-      } else if (fs.existsSync(skinPath)) {
-        fs.unlinkSync(skinPath);
-      }
-      delete configToSave.skin_background;
-    }
+    persistSkinBackground(configToSave);
     store.set(configToSave);
     console.log('[Config] Logical settings updated (Scanlines/LockTime).');
     return { success: true };

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -15,6 +15,59 @@ import { VpnView } from './components/VpnView';
 import { XMR402Modal } from './components/common/XMR402Modal';
 import { VaultProvider } from './contexts/VaultContext';
 
+type ViewId = 'home' | 'vault' | 'settings' | 'agent' | 'exchange' | 'vpn';
+
+interface NavButtonProps {
+  id: ViewId;
+  label: string;
+  icon: React.ComponentType<{ size?: number; className?: string }>;
+  badge?: string | null;
+  activeView: string;
+  onNavigate: (id: ViewId) => void;
+}
+
+const NavButton = ({ id, label, icon: Icon, badge, activeView, onNavigate }: NavButtonProps) => (
+  <button
+    onClick={() => onNavigate(id)}
+    className={`w-full flex items-center justify-between px-5 py-3 border-l-2 transition-all cursor-pointer group ${activeView === id ? 'bg-xmr-green/5 border-xmr-green text-xmr-green' : 'border-transparent text-xmr-dim hover:text-xmr-green hover:bg-xmr-green/5'}`}
+  >
+    <div className="flex items-center gap-3">
+      <Icon size={16} className={activeView === id ? 'drop-shadow-[0_0_8px_rgba(0,255,65,0.5)]' : 'opacity-50 group-hover:opacity-100'} />
+      <span className="text-[11px] font-black uppercase tracking-[0.15em]">{label}</span>
+    </div>
+    {badge && (
+      <span className="text-[9px] font-black bg-xmr-green/10 px-1.5 py-0.5 rounded-sm border border-xmr-green/20 animate-pulse">
+        {badge}
+      </span>
+    )}
+  </button>
+);
+
+interface NavGroupProps {
+  label: string;
+  groupKey: string;
+  expanded: boolean;
+  onToggle: (g: string) => void;
+  children: React.ReactNode;
+}
+
+const NavGroup = ({ label, groupKey, expanded, onToggle, children }: NavGroupProps) => {
+  const childArray = React.Children.toArray(children).filter(Boolean);
+  if (childArray.length === 1) return <>{childArray[0]}</>;
+  return (
+    <div>
+      <button
+        onClick={() => onToggle(groupKey)}
+        className="w-full flex items-center gap-2 px-5 py-1.5 text-[9px] font-black uppercase tracking-[0.25em] text-xmr-dim/60 hover:text-xmr-dim transition-colors cursor-pointer"
+      >
+        <ChevronRight size={10} className={`transition-transform duration-200 ${expanded ? 'rotate-90' : ''}`} />
+        {label}
+      </button>
+      {expanded && children}
+    </div>
+  );
+};
+
 const SkinOverlay = ({ config }: { config: any }) => {
   if (!config?.skin_background) return null;
   return (
@@ -32,7 +85,7 @@ const SkinOverlay = ({ config }: { config: any }) => {
 };
 
 function MainApp() {
-  const [view, setView] = useState<'home' | 'vault' | 'settings' | 'agent' | 'exchange' | 'vpn'>('home');
+  const [view, setView] = useState<ViewId>('home');
   const [showConsole, setShowConsole] = useState(false);
   const [consoleMaximized, setConsoleMaximized] = useState(false);
   const [consoleCopied, setConsoleCopied] = useState(false);
@@ -87,7 +140,6 @@ function MainApp() {
 
   const activeIdentity = identities.find(i => i.id === activeId);
 
-  const [showScanlines, setShowScanlines] = useState(resolvedTheme === 'dark');
   const [autoLockMinutes, setAutoLockMinutes] = useState(0);
 
   const [uplink, setUplink] = useState<string>('SCANNING...');
@@ -133,8 +185,6 @@ function MainApp() {
       const config = await window.api.getConfig();
       setAppConfig(config);
 
-      // Maintain compatibility with legacy single-setting logic
-      if (config.show_scanlines !== undefined) setShowScanlines(config.show_scanlines && resolvedTheme === 'dark');
       if (config.auto_lock_minutes !== undefined) setAutoLockMinutes(config.auto_lock_minutes);
     };
     loadConfig();
@@ -358,40 +408,6 @@ function MainApp() {
 
   const toggleGroup = (g: string) => setExpandedGroups(prev => ({ ...prev, [g]: !prev[g] }));
 
-  const NavButton = ({ id, label, icon: Icon, badge, compact }: any) => (
-    <button
-      onClick={() => setView(id)}
-      className={`w-full flex items-center justify-between px-5 py-3 border-l-2 transition-all cursor-pointer group ${view === id ? 'bg-xmr-green/5 border-xmr-green text-xmr-green' : 'border-transparent text-xmr-dim hover:text-xmr-green hover:bg-xmr-green/5'}`}
-    >
-      <div className="flex items-center gap-3">
-        <Icon size={16} className={view === id ? 'drop-shadow-[0_0_8px_rgba(0,255,65,0.5)]' : 'opacity-50 group-hover:opacity-100'} />
-        <span className="text-[11px] font-black uppercase tracking-[0.15em]">{label}</span>
-      </div>
-      {badge && (
-        <span className="text-[9px] font-black bg-xmr-green/10 px-1.5 py-0.5 rounded-sm border border-xmr-green/20 animate-pulse">
-          {badge}
-        </span>
-      )}
-    </button>
-  );
-
-  const NavGroup = ({ label, groupKey, children }: { label: string; groupKey: string; children: React.ReactNode }) => {
-    const childArray = React.Children.toArray(children).filter(Boolean);
-    if (childArray.length === 1) return <>{childArray[0]}</>;
-    return (
-      <div>
-        <button
-          onClick={() => toggleGroup(groupKey)}
-          className="w-full flex items-center gap-2 px-5 py-1.5 text-[9px] font-black uppercase tracking-[0.25em] text-xmr-dim/60 hover:text-xmr-dim transition-colors cursor-pointer"
-        >
-          <ChevronRight size={10} className={`transition-transform duration-200 ${expandedGroups[groupKey] ? 'rotate-90' : ''}`} />
-          {label}
-        </button>
-        {expandedGroups[groupKey] && children}
-      </div>
-    );
-  };
-
   return (
     <div className="flex h-screen bg-xmr-base text-xmr-green font-mono relative overflow-hidden select-none transition-colors duration-300">
       <SkinOverlay config={appConfig} />
@@ -445,17 +461,17 @@ function MainApp() {
 
         {/* ─── Grouped Navigation ─── */}
         <nav className="flex-grow overflow-y-auto custom-scrollbar space-y-1 pb-2" style={{ WebkitAppRegion: 'no-drag' } as any}>
-          <NavButton id="home" label="Dashboard" icon={Ghost} />
-          <NavButton id="vault" label="Vault" icon={Shield} badge={isSyncing ? `${syncPercent.toFixed(1)}%` : null} />
+          <NavButton id="home" label="Dashboard" icon={Ghost} activeView={view} onNavigate={setView} />
+          <NavButton id="vault" label="Vault" icon={Shield} badge={isSyncing ? `${syncPercent.toFixed(1)}%` : null} activeView={view} onNavigate={setView} />
 
-          <NavGroup label="Exchange" groupKey="exchange">
-            <NavButton id="exchange" label="Exchange" icon={ArrowDown} />
+          <NavGroup label="Exchange" groupKey="exchange" expanded={!!expandedGroups['exchange']} onToggle={toggleGroup}>
+            <NavButton id="exchange" label="Exchange" icon={ArrowDown} activeView={view} onNavigate={setView} />
           </NavGroup>
 
-          <NavGroup label="Tools" groupKey="tools">
-            <NavButton id="agent" label="Agent" icon={Bot} />
-            <NavButton id="settings" label="Settings" icon={Settings} />
-            <NavButton id="vpn" label="VPN" icon={Network} />
+          <NavGroup label="Tools" groupKey="tools" expanded={!!expandedGroups['tools']} onToggle={toggleGroup}>
+            <NavButton id="agent" label="Agent" icon={Bot} activeView={view} onNavigate={setView} />
+            <NavButton id="settings" label="Settings" icon={Settings} activeView={view} onNavigate={setView} />
+            <NavButton id="vpn" label="VPN" icon={Network} activeView={view} onNavigate={setView} />
           </NavGroup>
           <button
             onClick={() => { setShowFeedbackModal(true); setFeedbackText(''); }}

--- a/src/renderer/components/AuthView.tsx
+++ b/src/renderer/components/AuthView.tsx
@@ -203,7 +203,7 @@ export function AuthView({ onUnlock, isInitialSetup, identities, activeId, onSwi
 
         {/* 🔁 MIGRATION BANNER: wallets from a previous (Electron) Ripley install */}
         {!isProcessing && step === 'AUTH' && legacy.length > 0 && !importDismissed && (
-          <div className="flex items-center justify-between gap-3 px-4 py-2.5 bg-xmr-green/5 border border-xmr-green/30 rounded-lg">
+          <div className="flex items-center justify-between gap-3 px-4 py-2.5 bg-xmr-green/5 border border-xmr-green/30 rounded-sm">
             <span className="text-[11px] text-xmr-dim leading-snug">
               <span className="text-xmr-green font-black">↦ {legacy.length}</span> wallet{legacy.length > 1 ? 's' : ''} from your previous Ripley
             </span>
@@ -228,7 +228,7 @@ export function AuthView({ onUnlock, isInitialSetup, identities, activeId, onSwi
 
         {/* Expanded import list (only when the banner's Import is clicked) */}
         {!isProcessing && step === 'AUTH' && showImportList && !importDismissed && legacy.length > 0 && (
-          <div className="px-4 py-3 bg-xmr-surface/40 border border-xmr-border/30 rounded-lg flex flex-col gap-2">
+          <div className="px-4 py-3 bg-xmr-surface/40 border border-xmr-border/30 rounded-sm flex flex-col gap-2">
             <div className="text-[10px] text-xmr-dim/70 mb-1 leading-relaxed">
               Your funds are safe on disk — restore each with its seed phrase to use it here.
             </div>
@@ -341,9 +341,9 @@ export function AuthView({ onUnlock, isInitialSetup, identities, activeId, onSwi
             isn't buried three clicks deep. Tauri only. */}
         {/* Unlock (AUTH) or first-run create (no vault yet) — don't bury beta behind Settings. */}
         {canRos && !isProcessing && (step === 'AUTH' || (step === 'NEW_PASSWORD' && identities.length === 0)) && (
-          <div className="rounded-lg border border-xmr-green/25 bg-xmr-green/5 px-4 py-3.5 space-y-2.5">
+          <div className="rounded-sm border border-xmr-green/25 bg-xmr-green/5 px-4 py-3.5 space-y-2.5">
             <div className="flex items-start gap-3">
-              <span className="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-md border border-xmr-green/30 bg-xmr-base/60">
+              <span className="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-sm border border-xmr-green/30 bg-xmr-base/60">
                 <LayoutGrid size={16} className="text-xmr-green" />
               </span>
               <div className="min-w-0 flex-1 space-y-0.5">

--- a/src/renderer/components/HomeView.tsx
+++ b/src/renderer/components/HomeView.tsx
@@ -5,6 +5,23 @@ import { Card } from './Card';
 
 const SpreadChart = React.lazy(() => import('./SpreadChart'));
 
+interface RowProps {
+  label: string;
+  value: string | number | undefined;
+  highlight?: boolean;
+  alert?: boolean;
+  loading?: boolean;
+}
+
+const Row = ({ label, value, highlight = false, alert = false, loading = false }: RowProps) => (
+  <div className="flex justify-between items-center py-1.5 border-b border-xmr-border/10 group/row">
+    <span className="text-xs text-xmr-dim uppercase tracking-wider group-hover/row:text-xmr-green transition-colors">{label}</span>
+    <span className={`text-[11px] font-black tracking-tight ${alert ? 'text-xmr-accent animate-pulse' : (highlight ? 'text-xmr-green' : 'text-xmr-green/80')}`}>
+      {loading ? '---' : value}
+    </span>
+  </div>
+);
+
 interface HomeViewProps {
    setView: (v: 'home' | 'vault' | 'settings') => void;
   stats: any;
@@ -13,15 +30,6 @@ interface HomeViewProps {
 
 export function HomeView({ setView, stats, loading }: HomeViewProps) {
   const { resolvedTheme } = useTheme();
-
-  const Row = ({ label, value, highlight = false, alert = false }: any) => (
-    <div className="flex justify-between items-center py-1.5 border-b border-xmr-border/10 group/row">
-      <span className="text-xs text-xmr-dim uppercase tracking-wider group-hover/row:text-xmr-green transition-colors">{label}</span>
-      <span className={`text-[11px] font-black tracking-tight ${alert ? 'text-xmr-accent animate-pulse' : (highlight ? 'text-xmr-green' : 'text-xmr-green/80')}`}>
-        {loading ? '---' : value}
-      </span>
-    </div>
-  );
 
   return (
     <div className="max-w-6xl mx-auto space-y-10 py-4 animate-in fade-in duration-700 font-mono">
@@ -78,12 +86,12 @@ export function HomeView({ setView, stats, loading }: HomeViewProps) {
             <Activity size={16} /> Network_Uplink_Intel
           </h3>
           <div className="space-y-1">
-             <Row label="Current_Height" value={stats?.network.height} highlight />
-             <Row label="Hashrate_Agg" value={stats?.network.hashrate} />
-             <Row label="Network_Difficulty" value={stats?.network.difficulty} />
-             <Row label="Tx_Fees_Est" value={stats?.network.fees} highlight />
-             <Row label="Block_Reward" value={stats?.network.reward} />
-             <Row label="Mempool_Congestion" value={`${stats?.network.mempool || 0} TXs`} alert={(stats?.network.mempool || 0) > 50} />
+             <Row loading={loading} label="Current_Height" value={stats?.network.height} highlight />
+             <Row loading={loading} label="Hashrate_Agg" value={stats?.network.hashrate} />
+             <Row loading={loading} label="Network_Difficulty" value={stats?.network.difficulty} />
+             <Row loading={loading} label="Tx_Fees_Est" value={stats?.network.fees} highlight />
+             <Row loading={loading} label="Block_Reward" value={stats?.network.reward} />
+             <Row loading={loading} label="Mempool_Congestion" value={`${stats?.network.mempool || 0} TXs`} alert={(stats?.network.mempool || 0) > 50} />
           </div>
         </Card>
 
@@ -92,12 +100,12 @@ export function HomeView({ setView, stats, loading }: HomeViewProps) {
             <BarChart3 size={16} /> Market_Resistance_Analysis
           </h3>
           <div className="space-y-1">
-             <Row label="XMR_BTC_Ratio" value={stats?.market.xmr_btc} highlight />
-             <Row label="Market_Cap" value={stats?.market.cap} />
-             <Row label="24H_Volume" value={stats?.market.volume} />
-             <Row label="Circulating_Supply" value={stats?.market.supply} />
-             <Row label="P2P_Liquidity_Est" value={stats?.resistance.p2p_liquidity} highlight />
-             <Row label="Total_Nodes_Global" value={stats?.resistance.total_nodes} />
+             <Row loading={loading} label="XMR_BTC_Ratio" value={stats?.market.xmr_btc} highlight />
+             <Row loading={loading} label="Market_Cap" value={stats?.market.cap} />
+             <Row loading={loading} label="24H_Volume" value={stats?.market.volume} />
+             <Row loading={loading} label="Circulating_Supply" value={stats?.market.supply} />
+             <Row loading={loading} label="P2P_Liquidity_Est" value={stats?.resistance.p2p_liquidity} highlight />
+             <Row loading={loading} label="Total_Nodes_Global" value={stats?.resistance.total_nodes} />
           </div>
         </Card>
       </div>

--- a/src/renderer/components/SettingsView.tsx
+++ b/src/renderer/components/SettingsView.tsx
@@ -260,8 +260,8 @@ export function SettingsView() {
                     checked={localSettings.include_prereleases}
                     onChange={(e) => setLocalSettings({ ...localSettings, include_prereleases: e.target.checked })}
                   />
-                  <div className={`w-10 h-5 border flex items-center px-1 transition-all ${localSettings.include_prereleases ? 'border-xmr-accent bg-xmr-accent/10' : 'border-xmr-border bg-xmr-base'}`}>
-                    <div className={`w-3 h-3 transition-all ${localSettings.include_prereleases ? 'bg-xmr-accent translate-x-5' : 'bg-xmr-dim translate-x-0'}`} />
+                  <div className={`w-10 h-5 rounded-full border flex items-center px-1 transition-all ${localSettings.include_prereleases ? 'border-xmr-accent bg-xmr-accent/10' : 'border-xmr-border bg-xmr-base'}`}>
+                    <div className={`w-3 h-3 rounded-full transition-all ${localSettings.include_prereleases ? 'bg-xmr-accent translate-x-5' : 'bg-xmr-dim translate-x-0'}`} />
                   </div>
                 </label>
                 <button
@@ -433,7 +433,7 @@ export function SettingsView() {
             {/* Fast sync (trusts the node) */}
             <div className="flex items-start justify-between border-t border-xmr-border/10 pt-6 gap-4">
               <div className="space-y-1 flex-1">
-                <span className="text-xs text-amber-400 font-black uppercase">Fast_Sync ⚡</span>
+                <span className="text-xs text-xmr-warning font-black uppercase">Fast_Sync ⚡</span>
                 <p className="text-[11px] text-xmr-dim uppercase font-black leading-relaxed">
                   Sync dramatically faster (~50-100×) by bulk-downloading blocks.
                 </p>
@@ -447,7 +447,7 @@ export function SettingsView() {
               </div>
               <button
                 onClick={() => setLocalSettings({ ...localSettings, fast_sync: !localSettings.fast_sync })}
-                className={`shrink-0 mt-1 w-10 h-5 rounded-full relative transition-all cursor-pointer ${localSettings.fast_sync ? 'bg-amber-400' : 'bg-xmr-base border border-xmr-border'}`}
+                className={`shrink-0 mt-1 w-10 h-5 rounded-full relative transition-all cursor-pointer ${localSettings.fast_sync ? 'bg-xmr-warning' : 'bg-xmr-base border border-xmr-border'}`}
               >
                 <div className={`absolute top-0.5 w-3 h-3 rounded-full transition-all ${localSettings.fast_sync ? 'right-1 bg-xmr-base' : 'left-1 bg-xmr-border'}`}></div>
               </button>

--- a/src/renderer/components/SpreadChart.tsx
+++ b/src/renderer/components/SpreadChart.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useTheme } from '../hooks/useTheme';
 import {
   createChart,
@@ -37,27 +37,28 @@ export default function SpreadChart() {
     dateStr: string;
   } | null>(null);
 
-  const root = getComputedStyle(document.documentElement);
-  const brandColor = root.getPropertyValue('--brand-color').trim();
-  const borderColor = root.getPropertyValue('--border-color').trim();
-  const textPrimary = root.getPropertyValue('--text-primary').trim();
-  const textDim = root.getPropertyValue('--text-dim').trim();
-  const chartLine = root.getPropertyValue('--chart-line').trim();
-  const chartAreaTop = root.getPropertyValue('--chart-area-top').trim();
-  const chartGrid = root.getPropertyValue('--chart-grid').trim();
-  const textAccent = root.getPropertyValue('--text-accent').trim();
-
-  const colors = {
-    text: textPrimary || '#00ff41',
-    grid: chartGrid || 'rgba(20, 60, 20, 0.3)',
-    border: borderColor || '#004d13',
-    areaLine: chartLine || brandColor,
-    areaTop: chartAreaTop || 'rgba(0, 255, 65, 0.15)',
-    paperLine: textDim || '#64748b',
-    liqLine: textAccent || '#ea580c',
-    nodeLine: '#0891b2',
-    volColor: theme === 'light' ? 'rgba(4, 120, 87, 0.3)' : 'rgba(0, 50, 0, 0.5)',
-  };
+  const colors = useMemo(() => {
+    const root = getComputedStyle(document.documentElement);
+    const brandColor = root.getPropertyValue('--brand-color').trim();
+    const borderColor = root.getPropertyValue('--border-color').trim();
+    const textPrimary = root.getPropertyValue('--text-primary').trim();
+    const textDim = root.getPropertyValue('--text-dim').trim();
+    const chartLine = root.getPropertyValue('--chart-line').trim();
+    const chartAreaTop = root.getPropertyValue('--chart-area-top').trim();
+    const chartGrid = root.getPropertyValue('--chart-grid').trim();
+    const textAccent = root.getPropertyValue('--text-accent').trim();
+    return {
+      text: textPrimary || '#00ff41',
+      grid: chartGrid || 'rgba(20, 60, 20, 0.3)',
+      border: borderColor || '#004d13',
+      areaLine: chartLine || brandColor,
+      areaTop: chartAreaTop || 'rgba(0, 255, 65, 0.15)',
+      paperLine: textDim || '#64748b',
+      liqLine: textAccent || '#ea580c',
+      nodeLine: '#0891b2',
+      volColor: theme === 'light' ? 'rgba(4, 120, 87, 0.3)' : 'rgba(0, 50, 0, 0.5)',
+    };
+  }, [theme]);
 
   const toggleSeries = (key: keyof typeof visibleSeries) => {
     setVisibleSeries((prev: any) => ({ ...prev, [key]: !prev[key] }));

--- a/src/renderer/components/VaultView.tsx
+++ b/src/renderer/components/VaultView.tsx
@@ -331,7 +331,7 @@ export function VaultView({ setView, vault, handleBurn, appConfig }: VaultViewPr
                 {/* When some funds are locked (e.g. change still maturing), the headline
                     shows the TOTAL; surface the spendable portion so it's clear. */}
                 {currentAcc?.unlockedBalance && currentAcc.unlockedBalance !== currentAccBalance && (
-                  <div className="text-[10px] font-bold text-amber-500/80 uppercase tracking-[0.1em] mb-2">
+                  <div className="text-[10px] font-bold text-xmr-warning/80 uppercase tracking-[0.1em] mb-2">
                     {currentAcc.unlockedBalance} available · rest locked (maturing)
                   </div>
                 )}
@@ -375,7 +375,7 @@ export function VaultView({ setView, vault, handleBurn, appConfig }: VaultViewPr
                 <div className="space-y-1 mt-3 pt-3 border-t border-xmr-border/15">
                   <div className="flex justify-between text-[10px] uppercase font-black">
                     <span className="text-xmr-dim/40">Uplink:</span>
-                    <span className={`flex items-center gap-1 ${nodeStale ? 'text-yellow-500' : isSyncing ? 'text-xmr-accent' : 'text-xmr-green'}`}>
+                    <span className={`flex items-center gap-1 ${nodeStale ? 'text-xmr-warning' : isSyncing ? 'text-xmr-accent' : 'text-xmr-green'}`}>
                       {isSyncing && <Loader2 size={8} className="animate-spin" />}
                       {nodeStale ? `Node stale −${nodeLag}` : status}{nodeLabel ? ` (${nodeLabel})` : ''}
                       <button

--- a/src/renderer/components/common/XMR402Modal.tsx
+++ b/src/renderer/components/common/XMR402Modal.tsx
@@ -34,7 +34,7 @@ export const XMR402Modal: React.FC = () => {
       } else {
         // Deep Link Flow - Duplicate Prevention
         setPaymentStep('Checking cached payments...');
-        const cacheRes = await (window as any).api.getXmr402Payment(message);
+        const cacheRes = await window.api.getXmr402Payment(message);
         let finalTxid = '';
         let finalProof = '';
 
@@ -74,7 +74,7 @@ export const XMR402Modal: React.FC = () => {
           }
 
           // 3. Store Payment Record
-          await (window as any).api.saveXmr402Payment(message, finalTxid, finalProof, amount, returnUrl);
+          await window.api.saveXmr402Payment(message, finalTxid, finalProof, amount, returnUrl);
         }
 
         // 4. Handle Transparent Handback or Fallback to Success View

--- a/src/renderer/components/vault/AgentTab.tsx
+++ b/src/renderer/components/vault/AgentTab.tsx
@@ -67,7 +67,7 @@ export function AgentTab() {
 
   const handleRegenKey = async () => {
     if (confirm("Regenerate Agent API Key? Existing agent connections will be severed.")) {
-      const newKey = "RG-" + Math.random().toString(36).substring(2, 15).toUpperCase();
+      const newKey = "RG-" + crypto.randomUUID().replace(/-/g, '').substring(0, 13).toUpperCase();
       setApiKey(newKey);
       await syncConfig({ apiKey: newKey });
       alert("NEW_KEY_GENERATED: Update your agent configuration.");

--- a/src/renderer/components/vault/GhostSendTab.tsx
+++ b/src/renderer/components/vault/GhostSendTab.tsx
@@ -154,7 +154,7 @@ export function GhostSendTab({ onRequirePassword, onClose }: GhostSendTabProps) 
         // Save trade persistence for ledger tracking
         const tradeId = trade.trade_id || trade.id || '';
         if (tradeId && txHash) {
-          (window as any).api.saveGhostTrade(txHash, tradeId);
+          window.api.saveGhostTrade(txHash, tradeId);
         }
 
         setGhostPhase('tracking');
@@ -389,7 +389,7 @@ export function GhostSendTab({ onRequirePassword, onClose }: GhostSendTabProps) 
           <div
             onClick={() => {
               const url = `https://kyc.rip/swap?id=${tradeResponse?.trade_id || tradeResponse?.id}`;
-              (window as any).api.openExternal(url, { width: 940, height: 820 });
+              window.api.openExternal(url, { width: 940, height: 820 });
             }}
             className="text-[10px] text-xmr-accent hover:text-xmr-green underline uppercase tracking-tighter mt-2 cursor-pointer"
           >
@@ -408,7 +408,7 @@ export function GhostSendTab({ onRequirePassword, onClose }: GhostSendTabProps) 
           <div
             onClick={() => {
               const url = `https://kyc.rip/swap?id=${tradeResponse?.trade_id || tradeResponse?.id}`;
-              (window as any).api.openExternal(url, { width: 940, height: 820 });
+              window.api.openExternal(url, { width: 940, height: 820 });
             }}
             className="text-[10px] text-xmr-accent hover:text-xmr-green underline uppercase tracking-tighter cursor-pointer"
           >

--- a/src/renderer/components/vault/TransactionLedger.tsx
+++ b/src/renderer/components/vault/TransactionLedger.tsx
@@ -4,7 +4,6 @@ import { Card } from '../Card';
 import { TableHeader } from './TableHeader';
 import { AddressDisplay } from '../common/AddressDisplay';
 import { SubaddressInfo, useVault } from '../../contexts/VaultContext';
-import { RpcClient } from '../../services/rpcClient';
 import { useStats } from '../../hooks/useStats';
 
 interface Transaction {
@@ -98,7 +97,7 @@ export function TransactionLedger({ txs, subaddresses = [] }: TransactionLedgerP
   useEffect(() => {
     const fetchGhostTrades = async () => {
       try {
-        const result = await (window as any).api.getGhostTrades();
+        const result = await window.api.getGhostTrades();
         if (result.success) {
           setGhostTrades(result.trades || {});
         }
@@ -108,7 +107,7 @@ export function TransactionLedger({ txs, subaddresses = [] }: TransactionLedgerP
     };
     const fetchXmr402Payments = async () => {
       try {
-        const result = await (window as any).api.getAllXmr402Payments();
+        const result = await window.api.getAllXmr402Payments();
         if (result.success) {
           setXmr402Payments(result.payments || {});
         }
@@ -420,7 +419,7 @@ export function TransactionLedger({ txs, subaddresses = [] }: TransactionLedgerP
                                     const callbackUrl = new URL(decodeURIComponent(xmr402Info.returnUrl));
                                     callbackUrl.searchParams.set('xmr402_txid', tx.id);
                                     if (xmr402Info.proof) callbackUrl.searchParams.set('xmr402_proof', xmr402Info.proof);
-                                    (window as any).api.openExternal(callbackUrl.toString());
+                                    window.api.openExternal(callbackUrl.toString());
                                   }}
                                   className="shrink-0 ml-4 px-3 py-1.5 bg-xmr-warning hover:opacity-90 text-xmr-base text-[10px] font-black uppercase tracking-wider rounded-sm transition-colors cursor-pointer flex items-center gap-1 shadow-[0_0_10px_var(--warning-color)]"
                                 >
@@ -440,7 +439,7 @@ export function TransactionLedger({ txs, subaddresses = [] }: TransactionLedgerP
                                     e.stopPropagation();
                                     const tradeId = ghostTrades[tx.id].tradeId;
                                     const url = `https://kyc.rip/swap?id=${tradeId}`;
-                                    (window as any).api.openExternal(url, { width: 940, height: 820 });
+                                    window.api.openExternal(url, { width: 940, height: 820 });
                                   }}
                                   className="text-[10px] text-xmr-accent hover:text-xmr-green underline uppercase tracking-tighter flex items-center gap-1 cursor-pointer"
                                 >

--- a/src/renderer/hooks/useStats.ts
+++ b/src/renderer/hooks/useStats.ts
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo } from 'react';
+import { useState, useEffect, useCallback, useMemo } from 'react';
 
 export interface Stats {
   price: { paper: string; street: string; premium: string, source: string };
@@ -30,7 +30,7 @@ export function useStats() {
   const [stats, setStats] = useState<Stats | null>(null);
   const [loading, setLoading] = useState(true);
 
-  const fetchData = async () => {
+  const fetchData = useCallback(async () => {
     try {
       // Route through the configured uplink (Tor/SOCKS/clearnet) in the main
       // process — a direct clearnet fetch() here would leak the user's IP to the
@@ -44,7 +44,7 @@ export function useStats() {
     } finally {
       setLoading(false);
     }
-  };
+  }, []);
 
   useEffect(() => {
     fetchData();
@@ -52,5 +52,5 @@ export function useStats() {
     return () => clearInterval(interval);
   }, []);
 
-  return useMemo(() => ({ stats, loading, refresh: fetchData }), [stats, loading]);
+  return useMemo(() => ({ stats, loading, refresh: fetchData }), [stats, loading, fetchData]);
 }

--- a/src/renderer/services/client.ts
+++ b/src/renderer/services/client.ts
@@ -110,16 +110,9 @@ async function client<T>(type: APIType, endpoint: string, { body, ...customConfi
       return await customResponseHandler(result);
     }
 
-    const status = result.status;
-    const data = await result.json();
+    if (result.status === 204) return {} as T;
 
-    if (status === 204) return {} as T;
-
-    if (status >= 200 && status < 300) {
-      return data as T;
-    } else {
-      throw new APIError(data?.error || data?.message || `HTTP Error ${status}`, status, data);
-    }
+    return await result.json() as T;
   } catch (error: any) {
     if (error instanceof APIError) throw error;
     if (error.name === 'AbortError') throw new APIError('REQUEST_TIMEOUT', 408);

--- a/src/renderer/services/swap.ts
+++ b/src/renderer/services/swap.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { apiClient, apiClient as client } from './client';
+import { apiClient } from './client';
 import {
   type BatchQuoteRequest,
   type BatchQuoteResult,
@@ -233,7 +233,7 @@ export function createTrade(params: CreateTradeParams): Promise<ExchangeResponse
     });
   }
 
-  return client<ExchangeResponse>('/v2/exchange/create', {
+  return apiClient<ExchangeResponse>('/v2/exchange/create', {
     body: {
       ...params.extra,
       trade_id: params.id, amount_from: params.amountFrom, amount_to: params.amountTo,
@@ -308,7 +308,7 @@ export function getTradeStatus(id: string) {
     } as any);
   }
 
-  return client<TradeStatus>(`/v2/exchange/status/${id}`).then(normalizeTradeStatus) as Promise<TradeStatus>;
+  return apiClient<TradeStatus>(`/v2/exchange/status/${id}`).then(normalizeTradeStatus) as Promise<TradeStatus>;
 }
 
 /**
@@ -349,7 +349,7 @@ export async function fetchQuote(
     kyc: kycMap[kyc], log: logMap[log],
   });
 
-  return client<ExchangeQuote>(`/v2/exchange/estimate?${params.toString()}`);
+  return apiClient<ExchangeQuote>(`/v2/exchange/estimate?${params.toString()}`);
 }
 
 /**

--- a/src/renderer/window.d.ts
+++ b/src/renderer/window.d.ts
@@ -136,11 +136,11 @@ export interface IApi {
   // --- App Info & Updates ---
   getAppInfo: () => Promise<{ version: string; appDataPath: string; walletsPath: string; platform: NodeJS.Platform; isPackaged: boolean }>;
   openPath: (targetPath: string) => Promise<{ success: boolean; error?: string }>;
-  openExternal: (url: string) => Promise<{ success: boolean; error?: string }>;
+  openExternal: (url: string, options?: { width?: number; height?: number }) => Promise<{ success: boolean; error?: string }>;
   checkForUpdates: (include_prereleases: boolean) => Promise<{ success: boolean; hasUpdate?: boolean; latestVersion?: string; releaseUrl?: string; body?: string; publishedAt?: string; error?: string }>;
   selectBackgroundImage: () => Promise<{ success: boolean; data?: string; error?: string }>;
   saveGhostTrade: (txHash: string, tradeId: string) => Promise<{ success: boolean; error?: string }>;
-  getGhostTrades: () => Promise<{ success: boolean; trades: any[]; error?: string }>;
+  getGhostTrades: () => Promise<{ success: boolean; trades: Record<string, { tradeId: string; timestamp: number }>; error?: string }>;
 
   // XMR402 Payment Cache
   saveXmr402Payment: (nonce: string, txid: string, proof: string, amount: string, returnUrl?: string) => Promise<{ success: boolean; error?: string }>;


### PR DESCRIPTION
## Summary
- **Dead code cleanup**: removed unused imports (`React` in useStats, `RpcClient` in TransactionLedger, duplicate `apiClient` alias in swap.ts), removed unused `showScanlines` state from App.tsx
- **UI consistency**: AuthView `rounded-lg`/`rounded-md` → `rounded-sm` to match app-wide convention; added missing `rounded-full` to SettingsView pre-release toggle; replaced hardcoded `text-amber-*`/`text-yellow-*`/`bg-amber-400` with theme-aware `xmr-warning` tokens
- **Type safety**: removed unnecessary `(window as any).api` casts in GhostSendTab, XMR402Modal, and TransactionLedger (methods are properly typed in `window.d.ts`); fixed `openExternal` type to accept optional `{ width, height }`; fixed `getGhostTrades` return type from `any[]` to `Record<string, { tradeId, timestamp }>`
- **Security**: replaced `Math.random()` with `crypto.randomUUID()` for Agent Gateway API key generation
- **Performance**: moved `NavButton`/`NavGroup` (App.tsx) and `Row` (HomeView.tsx) from inline definitions to module scope with typed props — prevents component identity churn on every render; wrapped SpreadChart `getComputedStyle` reads in `useMemo`; wrapped `useStats.fetchData` in `useCallback` to stabilize memoized return value
- **Code dedup**: extracted `persistSkinBackground` helper in main/index.ts to eliminate copy-paste between `save-config-and-reload` and `save-config-only` handlers; removed unreachable error branch in client.ts

## Test plan
- [ ] Verify typecheck passes (`npm run typecheck`)
- [ ] Verify AuthView rounding matches VaultView/SettingsView visual style
- [ ] Verify SettingsView pre-release toggle renders as pill shape (rounded-full)
- [ ] Verify Fast Sync toggle + locked balance label use theme warning color across skins
- [ ] Verify Agent key regeneration produces valid keys
- [ ] Verify Ghost Send, XMR402, and Transaction Ledger still function (no runtime errors from `window.api` change)
- [ ] Verify SpreadChart renders correctly on theme switch

🤖 Generated with [Claude Code](https://claude.com/claude-code)