### PR TITLE
refactor: type safety cleanup and debug log removal

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -234,7 +234,6 @@ function MainApp() {
   // --- 🔗 DEEP LINK LISTENER ---
   useEffect(() => {
     const cleanup = window.api.onDeepLink((url: string) => {
-      console.log('[App] Received deep link:', url);
       try {
         const protocolRegex = /^(monero|ghost|ripley):([^?]+)(\?.*)?$/i;
         const match = url.match(protocolRegex);

--- a/src/renderer/components/SettingsView.tsx
+++ b/src/renderer/components/SettingsView.tsx
@@ -32,7 +32,7 @@ export function SettingsView() {
   const [isRescanning, setIsRescanning] = useState(false);
 
   // 📦 App Info & Updates state
-  const [appInfo, setAppInfo] = useState<{ version: string; appDataPath: string; walletsPath: string; platform: string } | null>(null);
+  const [appInfo, setAppInfo] = useState<Awaited<ReturnType<typeof window.api.getAppInfo>> | null>(null);
   const [isCheckingUpdate, setIsCheckingUpdate] = useState(false);
   const [updateResult, setUpdateResult] = useState<{
     checked: boolean;
@@ -69,7 +69,7 @@ export function SettingsView() {
       });
 
       const info = await window.api.getAppInfo();
-      setAppInfo(info as any);
+      setAppInfo(info);
     };
     loadInitialConfig();
   }, [currentIdentity]);
@@ -253,7 +253,7 @@ export function SettingsView() {
                       <div className="flex items-center gap-2 font-black uppercase text-xs">
                         <Zap size={14} className="animate-pulse" /> Update Available: v{updateResult.latestVersion}
                       </div>
-                      <button onClick={() => updateResult.releaseUrl && window.open(updateResult.releaseUrl)} className="flex items-center gap-1.5 px-3 py-1.5 bg-xmr-accent text-xmr-base hover:bg-white transition-colors cursor-pointer font-black uppercase">
+                      <button onClick={() => updateResult.releaseUrl && window.api.openExternal(updateResult.releaseUrl)} className="flex items-center gap-1.5 px-3 py-1.5 bg-xmr-accent text-xmr-base hover:bg-white transition-colors cursor-pointer font-black uppercase">
                         <Download size={10} /> Download Release
                       </button>
                     </div>
@@ -527,7 +527,7 @@ export function SettingsView() {
                       <label className="text-[10px] text-xmr-dim uppercase font-black block">Skin_Position</label>
                       <select
                         value={localSettings.skin_style}
-                        onChange={(e) => setLocalSettings({ ...localSettings, skin_style: e.target.value as any })}
+                        onChange={(e) => setLocalSettings({ ...localSettings, skin_style: e.target.value as 'cover' | 'contain' | 'tile' | 'top-left' })}
                         className="w-full bg-xmr-surface border border-xmr-border/50 p-2 text-xs text-xmr-green uppercase outline-none focus:border-xmr-accent"
                       >
                         <option value="cover">Cover (Center)</option>

--- a/src/renderer/components/VaultView.tsx
+++ b/src/renderer/components/VaultView.tsx
@@ -435,7 +435,7 @@ export function VaultView({ setView, vault, handleBurn, appConfig }: VaultViewPr
               {['ledger', 'coins', 'addresses', 'contacts'].map((t) => (
                 <button
                   key={t}
-                  onClick={() => setTab(t as any)}
+                  onClick={() => setTab(t as typeof tab)}
                   className={`px-4 py-2 text-[11px] font-black uppercase tracking-widest transition-all rounded-sm ${tab === t ? 'text-xmr-green border border-xmr-green/30 bg-xmr-green/5' : 'text-xmr-dim hover:text-xmr-green border border-transparent'}`}
                 >
                   {t}

--- a/src/renderer/components/common/XMR402Modal.tsx
+++ b/src/renderer/components/common/XMR402Modal.tsx
@@ -34,14 +34,13 @@ export const XMR402Modal: React.FC = () => {
       } else {
         // Deep Link Flow - Duplicate Prevention
         setPaymentStep('Checking cached payments...');
-        const cacheRes = await (window as any).api.getXmr402Payment(message);
+        const cacheRes = await window.api.getXmr402Payment(message);
         let finalTxid = '';
         let finalProof = '';
 
         if (cacheRes.success && cacheRes.payment) {
           // Re-use cached payment
           setPaymentStep('Cached payment found. Reusing...');
-          console.log('[XMR402] Cached payment found. Skipping physical execution.', cacheRes.payment);
           finalTxid = cacheRes.payment.txid;
           finalProof = cacheRes.payment.proof;
         } else {
@@ -74,7 +73,7 @@ export const XMR402Modal: React.FC = () => {
           }
 
           // 3. Store Payment Record
-          await (window as any).api.saveXmr402Payment(message, finalTxid, finalProof, amount, returnUrl);
+          await window.api.saveXmr402Payment(message, finalTxid, finalProof, amount, returnUrl);
         }
 
         // 4. Handle Transparent Handback or Fallback to Success View

--- a/src/renderer/components/vault/GhostSendTab.tsx
+++ b/src/renderer/components/vault/GhostSendTab.tsx
@@ -154,7 +154,7 @@ export function GhostSendTab({ onRequirePassword, onClose }: GhostSendTabProps) 
         // Save trade persistence for ledger tracking
         const tradeId = trade.trade_id || trade.id || '';
         if (tradeId && txHash) {
-          (window as any).api.saveGhostTrade(txHash, tradeId);
+          window.api.saveGhostTrade(txHash, tradeId);
         }
 
         setGhostPhase('tracking');
@@ -389,7 +389,7 @@ export function GhostSendTab({ onRequirePassword, onClose }: GhostSendTabProps) 
           <div
             onClick={() => {
               const url = `https://kyc.rip/swap?id=${tradeResponse?.trade_id || tradeResponse?.id}`;
-              (window as any).api.openExternal(url, { width: 940, height: 820 });
+              window.api.openExternal(url, { width: 940, height: 820 });
             }}
             className="text-[10px] text-xmr-accent hover:text-xmr-green underline uppercase tracking-tighter mt-2 cursor-pointer"
           >
@@ -408,7 +408,7 @@ export function GhostSendTab({ onRequirePassword, onClose }: GhostSendTabProps) 
           <div
             onClick={() => {
               const url = `https://kyc.rip/swap?id=${tradeResponse?.trade_id || tradeResponse?.id}`;
-              (window as any).api.openExternal(url, { width: 940, height: 820 });
+              window.api.openExternal(url, { width: 940, height: 820 });
             }}
             className="text-[10px] text-xmr-accent hover:text-xmr-green underline uppercase tracking-tighter cursor-pointer"
           >

--- a/src/renderer/components/vault/TransactionLedger.tsx
+++ b/src/renderer/components/vault/TransactionLedger.tsx
@@ -98,7 +98,7 @@ export function TransactionLedger({ txs, subaddresses = [] }: TransactionLedgerP
   useEffect(() => {
     const fetchGhostTrades = async () => {
       try {
-        const result = await (window as any).api.getGhostTrades();
+        const result = await window.api.getGhostTrades();
         if (result.success) {
           setGhostTrades(result.trades || {});
         }
@@ -108,7 +108,7 @@ export function TransactionLedger({ txs, subaddresses = [] }: TransactionLedgerP
     };
     const fetchXmr402Payments = async () => {
       try {
-        const result = await (window as any).api.getAllXmr402Payments();
+        const result = await window.api.getAllXmr402Payments();
         if (result.success) {
           setXmr402Payments(result.payments || {});
         }
@@ -420,7 +420,7 @@ export function TransactionLedger({ txs, subaddresses = [] }: TransactionLedgerP
                                     const callbackUrl = new URL(decodeURIComponent(xmr402Info.returnUrl));
                                     callbackUrl.searchParams.set('xmr402_txid', tx.id);
                                     if (xmr402Info.proof) callbackUrl.searchParams.set('xmr402_proof', xmr402Info.proof);
-                                    (window as any).api.openExternal(callbackUrl.toString());
+                                    window.api.openExternal(callbackUrl.toString());
                                   }}
                                   className="shrink-0 ml-4 px-3 py-1.5 bg-xmr-warning hover:opacity-90 text-xmr-base text-[10px] font-black uppercase tracking-wider rounded-sm transition-colors cursor-pointer flex items-center gap-1 shadow-[0_0_10px_var(--warning-color)]"
                                 >
@@ -440,7 +440,7 @@ export function TransactionLedger({ txs, subaddresses = [] }: TransactionLedgerP
                                     e.stopPropagation();
                                     const tradeId = ghostTrades[tx.id].tradeId;
                                     const url = `https://kyc.rip/swap?id=${tradeId}`;
-                                    (window as any).api.openExternal(url, { width: 940, height: 820 });
+                                    window.api.openExternal(url, { width: 940, height: 820 });
                                   }}
                                   className="text-[10px] text-xmr-accent hover:text-xmr-green underline uppercase tracking-tighter flex items-center gap-1 cursor-pointer"
                                 >

--- a/src/renderer/contexts/VaultContext.tsx
+++ b/src/renderer/contexts/VaultContext.tsx
@@ -282,12 +282,10 @@ export function VaultProvider({ children }: { children: React.ReactNode }) {
   // 🛡️ XMR402 Challenge Listeners
   useEffect(() => {
     const cleanupAgent = window.api.onAgentPay402?.((data: any) => {
-      console.log('[VaultContext] Received Agent XMR402 challenge:', data);
       setMonero402Challenge({ ...data, type: 'agent' });
     });
 
     const cleanupDeep = window.api.onXmr402Challenge?.((url: string) => {
-      console.log('[VaultContext] Received DeepLink XMR402 challenge:', url);
       try {
         const u = new URL(url.replace('xmr402://', 'http://402/'));
         const address = u.pathname.replace('/', '');

--- a/src/renderer/window.d.ts
+++ b/src/renderer/window.d.ts
@@ -92,7 +92,7 @@ export interface IApi {
   // --- App Info & Updates ---
   getAppInfo: () => Promise<{ version: string; appDataPath: string; walletsPath: string; platform: NodeJS.Platform; isPackaged: boolean }>;
   openPath: (targetPath: string) => Promise<{ success: boolean; error?: string }>;
-  openExternal: (url: string) => Promise<{ success: boolean; error?: string }>;
+  openExternal: (url: string, options?: { width?: number; height?: number }) => Promise<{ success: boolean; error?: string }>;
   checkForUpdates: (include_prereleases: boolean) => Promise<{ success: boolean; hasUpdate?: boolean; latestVersion?: string; releaseUrl?: string; body?: string; publishedAt?: string; error?: string }>;
   selectBackgroundImage: () => Promise<{ success: boolean; data?: string; error?: string }>;
   saveGhostTrade: (txHash: string, tradeId: string) => Promise<{ success: boolean; error?: string }>;


### PR DESCRIPTION
## Summary
- **Eliminate all `(window as any).api` casts** — the typed `IApi` interface in `window.d.ts` already covers every method called; 9 cast sites replaced with `window.api`
- **Fix `openExternal` type declaration** — add the `options?: { width?, height? }` param that the preload bridge and main process already accept
- **Improve type safety in SettingsView** — derive `appInfo` state type from the API return type; use a proper union for `skin_style` instead of `as any`
- **Fix VaultView tab cast** — `as typeof tab` instead of `as any`
- **Replace `window.open` with `window.api.openExternal`** — release URL now routes through the proper IPC channel
- **Remove 4 renderer debug `console.log` calls** — deep link handler, XMR402 challenge listeners, cached payment log

## Test plan
- [ ] Verify TypeScript compiles clean (`npx tsc --noEmit` — confirmed pre-push)
- [ ] Open a deep link (monero://) and confirm it still routes correctly
- [ ] Open Settings → check for updates → click Download Release → confirm it opens in browser
- [ ] Trigger an XMR402 deep link payment → confirm cached payment reuse works
- [ ] Ghost Send → complete flow → confirm External Status Tracker link opens
- [ ] Transaction Ledger → expand a Ghost/XMR402 tx → confirm external links work
- [ ] Change skin position in Settings → confirm dropdown saves correctly